### PR TITLE
Fills in Blank Aasimar Desc, Adds more Skintones, Fluffs up Skintones, Fixes Dark Elf being undead in desc, Makes skintones not named skin1-9

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -351,8 +351,11 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(use_skintones)
 
 //				dat += APPEARANCE_CATEGORY_COLUMN
+				var/skintone_word_swap = "Skin Tone" // Both the skintone names and the word swap here is useless fluff
+				if(pref_species.string_to_replace_skintone_on_charpref) // If they have a string in there on that var
+					skintone_word_swap = pref_species.string_to_replace_skintone_on_charpref // It is now in place of the word Skin Tone which will be the default.
 
-				dat += "<b>Skin Tone: </b><a href='?_src_=prefs;preference=s_tone;task=input'>Change </a>"
+				dat += "<b>[skintone_word_swap]: </b><a href='?_src_=prefs;preference=s_tone;task=input'>Change </a>"
 //				dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_SKIN_TONE]'>[(randomise[RANDOM_SKIN_TONE]) ? "Lock" : "Unlock"]</A>"
 				dat += "<br>"
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -117,6 +117,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	var/possible_faiths
 
+	//If you set a word here it swaps out the word skintone when the species is selected on the pref menu
+	var/string_to_replace_skintone_on_charpref = FALSE
+
 ///////////
 // PROCS //
 ///////////

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -16,7 +16,11 @@
 	the various challenges they face. Even if, in some irony: this behaviour \
 	leads the race towards technological advacement as they continue \
 	to improve their craft through powerful mechanization and forging \
-	Dwarves are hearty, but are not known for their speed or eyesight..."
+	Dwarves are hearty, but are not known for their speed or eyesight... \
+	Each dwarf hails from a ancient fortress named after the most plentiful mineral."
+
+	string_to_replace_skintone_on_charpref = "Fortress Origin"
+
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,YOUNGBEARD,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
@@ -64,12 +68,14 @@
 
 /datum/species/dwarf/mountain/get_skin_list()
 	return sortList(list(
-	"skin1" = "ffe0d1",
-	"skin2" = "fcccb3",
-	"skin3" = "edc6b3",
-	"skin4" = "e2b9a3",
-	"skin5" = "d9a284",
-	"skin6" = "c69b83"
+	"Platinum" = "ffe0d1",
+	"Aurum" = "fcccb3",
+	"Quicksilver" = "edc6b3",
+	"Brass" = "e2b9a3",
+	"Iron" = "d9a284",
+	"Malachite" = "c69b83",
+	"Obsidian" = "3b2e27",
+	"Brimstone" = "271f1a"
 	))
 
 /datum/species/dwarf/mountain/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -67,7 +67,7 @@
 	return message_language.spans
 
 /datum/species/dwarf/mountain/get_skin_list()
-	return sortList(list(
+	return list(
 	"Platinum" = "ffe0d1",
 	"Aurum" = "fcccb3",
 	"Quicksilver" = "edc6b3",
@@ -76,7 +76,7 @@
 	"Malachite" = "c69b83",
 	"Obsidian" = "3b2e27",
 	"Brimstone" = "271f1a"
-	))
+	)
 
 /datum/species/dwarf/mountain/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -84,7 +84,7 @@
 	return TRUE
 
 /datum/species/elf/dark/get_skin_list()
-	return sortList(list(
+	return list(
 	"Commorah" = "9796a9",
 	"Gloomhaven" = "897489",
 	"Darkpila" = "938f9c",
@@ -92,7 +92,7 @@
 	"Llurth Dreir" = "6a616d",
 	"Tafravma" = "5f5f70",
 	"Yuethindrynn" = "2F2F38",
-	))
+	)
 
 /datum/species/elf/dark/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -5,6 +5,18 @@
 	name = "Dark Elf"
 	id = "elf"
 	desc = "<b>Dark Elf</b><br>\
+	Elves, are a generic term for tall, pointy-eared humanoids\
+    Of whom trace their original heritage to the ancient mysterious Snow Elves. \
+	These ones are of a dark complexion and originate mostly from the underdark. \
+    Their culture and entire lives normally involve serving Lolth, the spider queen. \
+    Previously rare but in recent times, more and more dark elfs can be seen on the surface\
+    It's rumored that Lolth has been weakened and her power wanes over the dark elfs. \
+    The ones who aren't overtly cruel and bloodthirsty; tend to flee to the surface lest they get culled by their own society, \
+    While some more sinister ones abandon Lolth in search of new and greater power."
+
+/*
+	Former RT Desc: These guys were undead which doesn't really fit considering now you have a ton of them walking around.
+
 	Descending from a perversion of necromancy, Dark Elves are a unique species \
 	that have only recently found themselves a staple of daily life. \
 	They boast a proud, beauty-centric culture that demands only the finest \
@@ -14,7 +26,11 @@
 	Dark Elves tend to be extremely arrogant of others plights, with selfishness\
 	being seen as a massive boon in their society. They are academic and usually well taught\
 	through are noted to suffer from their biology, which tends to be weak and falls apart\
-	without careful upkeep..."
+	without careful upkeep...\
+	They typically trace their beginnings to how their progenator died before being raised."
+*/
+	string_to_replace_skintone_on_charpref = "Origin City-State"
+
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = list("mcolor" = "FFF", "ears" = "ElfW", "wings" = "None")
@@ -44,7 +60,7 @@
 	OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 	OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0))
 	specstats = list("strength" = -2, "perception" = -1, "intelligence" = 1, "constitution" = -1, "endurance" = 1, "speed" = 2, "fortune" = 0)
-	specstats_f = list("strength" = -1, "perception" = -2, "intelligence" = 2, "constitution" = -1, "endurance" = 1, "speed" = 1, "fortune" = 0)
+	specstats_f = list("strength" = 1, "perception" = -1, "intelligence" = 2, "constitution" = 0, "endurance" = 1, "speed" = 1, "fortune" = 0)
 	enflamed_icon = "widefire"
 	possible_faiths = list(FAITH_SPIDER)
 
@@ -69,12 +85,13 @@
 
 /datum/species/elf/dark/get_skin_list()
 	return sortList(list(
-	"skin1" = "9796a9",
-	"skin2" = "897489",
-	"skin3" = "938f9c",
-	"skin4" = "737373",
-	"skin5" = "6a616d",
-	"skin6" = "5f5f70"
+	"Commorah" = "9796a9",
+	"Gloomhaven" = "897489",
+	"Darkpila" = "938f9c",
+	"Sshanntynlan" = "737373",
+	"Llurth Dreir" = "6a616d",
+	"Tafravma" = "5f5f70",
+	"Yuethindrynn" = "2F2F38",
 	))
 
 /datum/species/elf/dark/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -66,7 +66,7 @@
 	return message_language.spans
 
 /datum/species/elf/snow/get_skin_list()
-	return sortList(list(
+	return list(
 	"Dandelion Creek" = "ffe0d1",
 	"Roseveil" = "fcccb3",
 	"Azuregrove" = "edc6b3",
@@ -74,7 +74,7 @@
 	"Almondvalle" = "c9a893",
 	"Walnut Woods" = "ba9882",
 	"Timberborn" = "5d4c41"
-	))
+	)
 
 /datum/species/elf/snow/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -6,7 +6,7 @@
 	id = "elf"
 	desc = "<b>Elf</b><br>\
 	Elves, or Wood-Elf by the Elder races, are a generic term for tall, pointy-eared \
-	humanoids that trace their original heritage to the ancient Snow Elves. \
+	humanoids that trace their original heritage to the ancient mysterious Snow Elves. \
 	Considering their diverse history, it is extremely difficult for other mortals \
 	to even concept the various intricacies found in elven society, and the hundreds \
 	if not thousands of tribes that exist within their culture! \
@@ -14,7 +14,11 @@
 	been rivals in various conflicts and territorial disputes. This however does not stop \
 	many humans and elves from forming relationships, which are capable of producing child.\
 	Elves are known for their intelligence and sharp eyes, but their graceful nature does \
-	not lend itself to the concepts of strength or durability..."
+	not lend itself to the concepts of strength or durability... \
+	There are elves from a small smattering of tribes in these parts."
+
+	string_to_replace_skintone_on_charpref = "Tribal Identity"
+
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
@@ -63,12 +67,13 @@
 
 /datum/species/elf/snow/get_skin_list()
 	return sortList(list(
-	"skin1" = "ffe0d1",
-	"skin2" = "fcccb3",
-	"skin3" = "edc6b3",
-	"skin4" = "e2b9a3",
-	"skin5" = "c9a893",
-	"skin6" = "ba9882"
+	"Dandelion Creek" = "ffe0d1",
+	"Roseveil" = "fcccb3",
+	"Azuregrove" = "edc6b3",
+	"Arborshome" = "e2b9a3",
+	"Almondvalle" = "c9a893",
+	"Walnut Woods" = "ba9882",
+	"Timberborn" = "5d4c41"
 	))
 
 /datum/species/elf/snow/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humann.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humann.dm
@@ -51,7 +51,7 @@
 	return TRUE
 
 /datum/species/human/northern/get_skin_list()
-	return sortList(list(
+	return list(
 	"Grenzelhoft" = "fff0e9",
 	"Hammerhold" = "ffe0d1",
 	"Avar" = "fcccb3",
@@ -63,7 +63,7 @@
 	"Shalvistine" = "ac8369",
 	"Lalvestine" = "9c6f52",
 	"Ebon" = "4e3729"
-	))
+	)
 
 /datum/species/human/northern/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humann.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humann.dm
@@ -12,6 +12,9 @@
 	have historically been at odds with one another. Being the eldest of the weeping God, humen\
 	tend to find fortune easier than the other races, and are so diverse that no other racial trait\
 	are dominant in their species..."
+
+	string_to_replace_skintone_on_charpref = "Ancestry"
+
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
@@ -49,15 +52,17 @@
 
 /datum/species/human/northern/get_skin_list()
 	return sortList(list(
-	"skin1" = "ffe0d1",
-	"skin2" = "fcccb3",
-	"skin3" = "edc6b3",
-	"skin4" = "e2b9a3",
-	"skin5" = "d9a284",
-	"skin6" = "c9a893",
-	"skin7" = "ba9882",
-	"skin8" = "ac8369",
-	"skin9" = "9c6f52"
+	"Grenzelhoft" = "fff0e9",
+	"Hammerhold" = "ffe0d1",
+	"Avar" = "fcccb3",
+	"Rockhill" = "edc6b3",
+	"Otava" = "e2b9a3",
+	"Etrusca" = "d9a284",
+	"Gronn" = "c9a893",
+	"Giza" = "ba9882",
+	"Shalvistine" = "ac8369",
+	"Lalvestine" = "9c6f52",
+	"Ebon" = "4e3729"
 	))
 
 /datum/species/human/northern/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -4,7 +4,18 @@
 /datum/species/aasimar
 	name = "Aasimar"
 	id = "aasimar"
-	desc = ""
+	desc = "<b>Aasimar</b><br>\
+	Aasimar are born of a rare union between Humans and Angels. \
+	They bear the mark of their celestial touch through many varying physical features. \
+	Their looks resemble the traditional characteristics of whichever of the Gods the Angel parent was associated with. \
+	Most commonly, Aasimar are similar to Humans, albeit taller, and possess uncanny beauty. \
+	They have strangely colored skin and are more physically frail than the average Human. \
+	Because of their upbringing, they make for natural conduits for godly powers. \
+	Rockhills populace holds them with a mixture of uneasy fear or, and respect. \
+	It is also widely believed that an Aasimars death is a bad omen..."
+
+	string_to_replace_skintone_on_charpref = "Crafted With"
+
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = list("mcolor" = "FFF", "wings" = "None")
@@ -82,8 +93,12 @@
 	"Planetar" = "ffd859",
 	"Deva"	   = "b6f1f2",
 	"Solar" = "daeaeb",
-	"Empyrean" = "a9ded1",
-	"Gaeian" = "db874f"
+	"Empyrea" = "a9ded1",
+	"Gaeia" = "db874f",
+	"Celestial" = "e1c565",
+	"Olympia" = "C7f9cc",
+	"Necral" = "23130c",
+	"Abyssal" = "22577a"
 	))
 
 /datum/species/aasimar/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -89,7 +89,7 @@
 	return TRUE
 
 /datum/species/aasimar/get_skin_list()
-	return sortList(list(
+	return list(
 	"Planetar" = "ffd859",
 	"Deva"	   = "b6f1f2",
 	"Solar" = "daeaeb",
@@ -99,7 +99,7 @@
 	"Olympia" = "C7f9cc",
 	"Necral" = "23130c",
 	"Abyssal" = "22577a"
-	))
+	)
 
 /datum/species/aasimar/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -11,8 +11,11 @@
 	worry that someday, it may be impossible to distinguish the two species. \
 	Half-Elves are extremely diverse, as they bring in human and elvish culture\
 	and it is widely considered that Half-Elf culture is simply a melting pot of \
-	various other cultures condensing into one vibrant entity.\
-	Due to their heritage, Half-Elves dont tend to gain or suffer from any racial traits..."
+	various other cultures condensing into one vibrant entity. \
+	Due to their heritage, Half-Elves tend to gain racial traits depending on how strong their fathers, or mothers, genes were. \
+	Half-Elves also typically try to find identity in one of two regions they have similarities towards."
+
+	string_to_replace_skintone_on_charpref = "Identifies As"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
@@ -50,10 +53,11 @@
 
 /datum/species/human/halfelf/get_skin_list()
 	return sortList(list(
-	"skin1" = "ffe0d1",
-	"skin2" = "fcccb3",
-	"skin3" = "edc6b3",
-	"skin4" = "e2b9a3"
+	"Timber-Gronn" = "ffe0d1",
+	"Giza-Azure" = "fcccb3",
+	"Walnut-Stine" = "edc6b3",
+	"Etrustcan-Dandelion" = "e2b9a3",
+	"Ebon-Born" = "5a4a41"
 	))
 
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -52,13 +52,13 @@
 	return TRUE
 
 /datum/species/human/halfelf/get_skin_list()
-	return sortList(list(
+	return list(
 	"Timber-Gronn" = "ffe0d1",
 	"Giza-Azure" = "fcccb3",
 	"Walnut-Stine" = "edc6b3",
 	"Etrustcan-Dandelion" = "e2b9a3",
 	"Ebon-Born" = "5a4a41"
-	))
+	)
 
 
 /datum/species/human/halfelf/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -9,13 +9,16 @@
 	Having shown up sometime within the past two centuries, very little is known about their culture \
 	as many seem to simply intergrate within whatever society they find themselves in. \
 	Tieflings usually cause strong disturbances with their presence, as their fiendish looks \
-	have claimed that they are the spawn of a succubus (Or incubus) laying with a mortal. \
+	Many have claimed that they are the spawn of a succubus (Or incubus) laying with a mortal. \
 	In this, their species has suffered vast tragedy throughout their short history, \
 	Facing scrutiny, judgement and even genocide in the past. Wounding many tiefling psyche \
 	and leading to most seeking a solitary life outside the watchful eyes of others. \
 	Tiefling cannot reproduce with mortals, and so no half-breed exists. \
 	Tiefling tend to be extremely perceptive and paranoid, as luck is rarely on their side \
 	and their unique biology makes them extremely susceptible to injury."
+
+	string_to_replace_skintone_on_charpref = "Progenitor"
+
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = list("mcolor" = "FFF", "ears" = "ElfW", "tail_human" = "TiebTail", "horns" = "TiebHorns")
@@ -94,9 +97,9 @@
 /datum/species/tieberian/get_skin_list()
 	return sortList(list(
 	"Castillian" = "cc5757",
-	"Devil" = "ff0000",
-	"Wicked" = "D2042D",
-	"Gypsy" = "a23737"
+	"Unknown" = "ff0000",
+	"Succubus" = "D2042D",
+	"Incubus" = "a23737"
 	))
 
 /datum/species/tieberian/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -95,12 +95,12 @@
 	return TRUE
 
 /datum/species/tieberian/get_skin_list()
-	return sortList(list(
+	return list(
 	"Castillian" = "cc5757",
 	"Unknown" = "ff0000",
 	"Succubus" = "D2042D",
 	"Incubus" = "a23737"
-	))
+	)
 
 /datum/species/tieberian/get_hairc_list()
 	return sortList(list(


### PR DESCRIPTION
With the help of the community, we gave Aasimar a desc since it was previously blank.
Dark elf was also undead by default and now they are not.
Adds some more skintones to pick from and adds some useless background lore so they aren't named skin1-9.