### PR TITLE
fix reset button breaking layout

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1373,7 +1373,7 @@ Slots: [job.spawn_positions]</span>
 				ShowChoices(user,4)
 			if("reset")
 				ResetJobs()
-				SetChoices(user,4)
+				SetChoices(user)
 			if("triumphthing")
 				ResetLastClass(user)
 			if("nojob")


### PR DESCRIPTION
Currently, if you press the "Reset" button in job preferences, the layout of jobs breaks.

This prevents it from breaking. Tested to ensure reset functionality still updates list of available jobs.