### PR TITLE
remove duplicate psicrosses

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -193,22 +193,6 @@
 	resistance_flags = FIRE_PROOF
 	sellprice = 100
 
-/obj/item/clothing/neck/roguetown/psicross/necra
-	name = "golden psycross"
-	desc = ""
-	icon_state = "psicrossg"
-	//dropshrink = 0.75
-	resistance_flags = FIRE_PROOF
-	sellprice = 100
-
-/obj/item/clothing/neck/roguetown/psicross/noc
-	name = "golden psycross"
-	desc = ""
-	icon_state = "psicrossg"
-	//dropshrink = 0.75
-	resistance_flags = FIRE_PROOF
-	sellprice = 100
-
 /obj/item/clothing/neck/roguetown/talkstone
 	name = "talkstone"
 	desc = ""


### PR DESCRIPTION
There were two duplicate psicross objects. These seemed to be unnecessary as they were named after pre-existing psicrosses but using all the properties of the gold psicross- which already has its own object.

This was causing issues where players could never get the correct psicross for some of the gods.