### PR TITLE
Paladin Nerf

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/templar.dm
@@ -26,7 +26,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
@@ -34,7 +34,7 @@
 		backl = /obj/item/rogueweapon/sword/long
 		H.change_stat("strength", 2)
 		H.change_stat("perception", 2)
-		H.change_stat("intelligence", 2)
+		H.change_stat("intelligence", -2)
 		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", -2)


### PR DESCRIPTION
Reduces the sword skill of paladins from expert (lvl 4) down to skilled (lvl 3) to be more in line with other adventurer classes starting skill level. Still an overtuned class that starts with the best helmet variant and healing. Hopefully this change will at the very least delay the murderboning of the entire nobility and beggars. 

The intelligence is reduced to try to slow down training speed (although I rarely see paladins train they just go ham at the start). The paladins still have a above average physical attribute bonus and considering the current playstyle of paladins are well-armed marauders (basically crusaders). 
