### PR TITLE
Lesser Heal Obliteration

### DIFF
--- a/code/modules/spells/roguetown/cleric.dm
+++ b/code/modules/spells/roguetown/cleric.dm
@@ -85,12 +85,12 @@
 			var/mob/living/carbon/C = target
 			var/obj/item/bodypart/affecting = C.get_bodypart(check_zone(user.zone_selected))
 			if(affecting)
-				if(affecting.heal_damage(20, 20, 0, null, FALSE))
+				if(affecting.heal_damage(0, 0, 0, null, FALSE))
 					C.update_damage_overlays()
 				if(affecting.heal_wounds(50))
 					C.update_damage_overlays()
 		else
-			target.adjustBruteLoss(-5)
+			target.adjustBruteLoss(-1)
 			target.adjustFireLoss(-5)
 		target.adjustToxLoss(-5)
 		target.adjustOxyLoss(-5)


### PR DESCRIPTION
Its a crutch that circumnavigates sleeping in a bed. Removed most of the healing damage aspect, can only be used to stabilize wounds such as bleeding. Bed healing gameplay is essential as it is a moment of vulnerability one has to experience (more rp with group less murder hobo). This should also tone down the strength of paladin/cleric while keeping the church viable.

