### PR TITLE
Makes zombies unable to be made until overlays cleanup

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -45,9 +45,10 @@
 				dust(just_ash=TRUE,drop_items=TRUE)
 				return
 
-	if(!gibbed)
-		if(!is_in_roguetown(src))
-			zombie_check()
+	//4/15/2024 - Removes the thing that actually griefs people the most when it goes invisible from the mass overlay segment added to the SS, will come back at some point
+	//if(!gibbed)
+	//	if(!is_in_roguetown(src))
+			//zombie_check()
 
 	if(client || mind)
 		SSticker.deaths++


### PR DESCRIPTION
Alas, anything over 100 overlays now gets cut and goes invisible, mostly occurring from them hitting each other. Zombies being killed and coming back usually manage to hit that point, so for now there shouldn't be invisible antags at the very least.