### PR TITLE
Replace ass slapping with belly popping

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -602,8 +602,8 @@
 	message_param = initial(message_param) // reset
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.zone_selected == BODY_ZONE_PRECISE_GROIN)
-			message_param = "slaps %t on the ass!"
+		if(H.zone_selected == BODY_ZONE_PRECISE_STOMACH)
+			message_param = "pops %t's belly!"
 	..()
 
 /mob/living/carbon/human/verb/emote_slap()


### PR DESCRIPTION
Slapping asses is still in the code and is a fast trip to banville. Instead, players can now pop bellies.