### PR TITLE
Tree stumps can now be chopped for wood

### DIFF
--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -177,7 +177,6 @@
 	static_debris = list(/obj/item/grown/log/tree = 1)
 	climb_offset = 14
 	stump_type = FALSE
-	
 
 /obj/structure/flora/roguetree/stump/log/Initialize()
 	. = ..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -156,9 +156,9 @@
 	climb_time = 0
 	layer = TABLE_LAYER
 	plane = GAME_PLANE
-	blade_dulling = DULLING_PICK
-	static_debris = null
-	debris = null
+	blade_dulling = DULLING_CUT
+	debris = list(/obj/item/grown/log/tree/stick = 1)
+	static_debris = list(/obj/item/grown/log/tree/small = 1)
 	alpha = 255
 	pixel_x = -16
 	climb_offset = 14
@@ -177,6 +177,7 @@
 	static_debris = list(/obj/item/grown/log/tree = 1)
 	climb_offset = 14
 	stump_type = FALSE
+	
 
 /obj/structure/flora/roguetree/stump/log/Initialize()
 	. = ..()


### PR DESCRIPTION
Makes removing stumps slightly more intuitive.

Before this, you removed stumps with pickaxes and wooden stakes in one hit and got nothing back from it.

Now, you chop them with the same axe you used to chop down the tree to begin with, and you get some amount of wood from it.

(I mean technically you're supposed to dig them out with like a shovel or pull them out with a cow and rope but a woodchopper wouldn't normally have either of those and also i really don't want to have to code a special interaction)