### PR TITLE
Fixes heartfelt lord not spawning with an emerald ring

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
@@ -18,9 +18,9 @@
 	cloak = /obj/item/clothing/cloak/heartfelt
 	armor = /obj/item/clothing/suit/roguetown/armor/heartfelt/lord
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
-	beltl = /obj/item/scomstone
-	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	beltl = /obj/item/rogueweapon/sword/long/marlin
+	gloves = /obj/item/clothing/gloves/roguetown/leather/black
+	id = /obj/item/scomstone
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
@@ -18,9 +18,9 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	beltl = /obj/item/rogueweapon/sword/decorated
-	beltr = /obj/item/scomstone
 	backr = /obj/item/storage/backpack/rogue/satchel/heartfelt
 	mask = /obj/item/clothing/mask/rogue/spectacles/golden
+	id = /obj/item/scomstone
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -128,7 +128,7 @@
 /obj/item/scomstone
 	name = "emerald ring"
 	icon_state = "ring_emerald"
-	desc = "A golden ring with a emerald gem."
+	desc = "A golden ring with an emerald gem."
 	gripped_intents = null
 	dropshrink = 0.75
 	possible_item_intents = list(INTENT_GENERIC)


### PR DESCRIPTION
Attempts to close #65

Issue was the heartfealt lord was spawning with two items in their `beltl` slot, the second one overriding the first like this:
![image](https://github.com/Blackstone-SS13/BLACKSTONE/assets/143908044/87b2f800-2335-458d-80b7-f535396ba225)




So without testing, this new code looks right. ID slot appears to be the ring slot, so both the hand and the lord should now spawn with their emerald rings sitting comfortably on their fingers. Lemme know if ye think it should spawn elsewhere.