### PR TITLE
Simple Orc Language

### DIFF
--- a/code/modules/language/roguetown/orc.dm
+++ b/code/modules/language/roguetown/orc.dm
@@ -1,0 +1,31 @@
+/datum/language/orc
+	name = "Orcish"
+	desc = "A language commonly spoken by orcs"
+	speech_verb = "says"
+	ask_verb = "asks"
+	exclaim_verb = "yells"
+	key = "o"
+	flags = LANGUAGE_HIDE_ICON_IF_UNDERSTOOD | LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD
+	space_chance = 66
+	default_priority = 80
+	icon_state = "asse"
+	spans = list(SPAN_ORC)
+	syllables = list(
+"an",
+"ar",
+"da",
+"du",
+"de",
+"dg",
+"ga",
+"gu",
+"ka",
+"ku",
+"ma",
+"mo",
+"ne",
+"te",
+"ug",
+"ur",
+"uk",
+"zu")


### PR DESCRIPTION
Adds very simple & basic format orc language to the code based on dictionary from D&D campaign Forgotten Realms. Very simple, nothing extensive.