### PR TITLE
Fixes lore primer formatting and removes mentions of Roguetown from it

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -349,7 +349,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	var/list/dat = list()
 	dat += GLOB.roleplay_readme
 	if(dat)
-		var/datum/browser/popup = new(src, "Primer", "RT", 460, 550)
+		var/datum/browser/popup = new(src, "Primer", "BLACKSTONE", 460, 550)
 		popup.set_content(dat.Join())
 		popup.open()
 

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -1,4 +1,5 @@
-(Welcome to Roguetown)
+(Welcome to BLACKSTONE)
+<br>
 It is the age of abandonment
 <br><br>
 It is the year 1522, the world has recently seen the end of a massive conflict known as the War in the Mists between the two major nations of the world. To the west, the Zybatine Empire has grown out of the remnants of the Golden-Bridge Empire of old, its name lost to the annals of time and the greed of its sultans.
@@ -6,6 +7,6 @@ To the east, the Grenzelhofts have carved an imperiate out of the various tribes
 <br><br>
 However, not all places are afflicted as miserably by the growing pains of a new era. Such as the place our story takes place: Rockhill. The mantlepiece of a small petty kingdom on the Isle of Enigma, this township has long since stood upon the burrows of a much more ancient and mysterious empire of old. This town is a melting pot of cultural, political and martial history, with it being a cornerstone location where adventurers and townsfolk alike congregate to share in its rather impressive wealth and quality of living compared to other borderstates.
 <br><br>
-A typical role-play character in Roguetown comes from a diverse set of backgrounds, experiences, and world-views. It is up to you, the player: to decide how to portray such a complex history through your character. You may be a good person looking to the betterment of your daily lot in life, morally grey and survival focused or a terrible whoreson of little morality. This is your story to create.
+A typical role-play character in BLACKSTONE comes from a diverse set of backgrounds, experiences, and world-views. It is up to you, the player: to decide how to portray such a complex history through your character. You may be a good person looking to the betterment of your daily lot in life, morally grey and survival focused or a terrible whoreson of little morality. This is your story to create.
 <br><br>
 Will you go down in legend or falter into obscurity this day?


### PR DESCRIPTION
Fixes this (this isn't Roguetown as far as I'm aware)
![image](https://github.com/Blackstone-SS13/BLACKSTONE/assets/143908044/47f77f8f-ff7d-4415-9708-f346be46b5cd)
