### PR TITLE
blacksmith can now set up shop

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -18,7 +18,7 @@
 	..()
 	beltr = /obj/item/rogueweapon/hammer
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/rogueweapon/tongs=1)
+	backpack_contents = list(/obj/item/rogueweapon/tongs=1, /obj/item/rogueore/coal=1, /obj/item/rogueore/iron=1)
 	if(H.gender == MALE)
 		pants = /obj/item/clothing/under/roguetown/trou
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather


### PR DESCRIPTION
pilgrim classes already get it pretty hard, and blacksmith really has it the worst.

if they don't make it to town/city, they can't do squat. 

i highly doubt that people will play blacksmith just to spawn one iron ore so it shouldn't really affect the iron economy at all.

they still won't be able to do much except make a forge and anvil to repair items and _maybe_ scrap weapons and armor from dead nerds in the woods but it'll definitely be better than the actual jack diddly they got right now

i'll probably take a look at cheesemaker next, maybe give them some bait and grain to tame a goat or something