### PR TITLE
More flexible floor crafting

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -10,10 +10,9 @@
 /datum/crafting_recipe/roguetown/turfs/woodfloor/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
-	if(!istype(T, /turf/open/floor/rogue/dirt))
+	if(!istype(T, /turf/open/floor/rogue))
 		if(!istype(T, /turf/open/transparent/openspace))
-			if(!istype(T, /turf/open/floor/rogue/grass))
-				return
+			return
 	return TRUE
 
 /datum/crafting_recipe/roguetown/turfs/woodwall
@@ -52,10 +51,9 @@
 /datum/crafting_recipe/roguetown/turfs/stonefloor/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
 		return
-	if(!istype(T, /turf/open/floor/rogue/dirt))
+	if(!istype(T, /turf/open/floor/rogue))
 		if(!istype(T, /turf/open/transparent/openspace))
-			if(!istype(T, /turf/open/floor/rogue/grass))
-				return
+			return
 	return TRUE
 
 /datum/crafting_recipe/roguetown/turfs/stonewall


### PR DESCRIPTION
Allows building over existing floors (before was only allowed for dirt). Been dwarf fortressing and it hurts my soul that we cannot build over the existing floors only the dirt.

![image](https://github.com/Blackstone-SS13/BLACKSTONE/assets/126647931/53304c4f-cf06-475e-ac95-4da3a4f9bd9c)
