### PR TITLE
Adds more safety to insure underworld tolls never run out.

### DIFF
--- a/code/modules/underworld/underworld.dm
+++ b/code/modules/underworld/underworld.dm
@@ -106,6 +106,7 @@
 			to_chat(ghost, "<br><font color=purple><span class='bold'>THE TOLL IS PAID, THROUGH THE CARRIAGE THE UNDERMAIDEN WAITS.</span></font>")
 			user << sound(pick('sound/misc/carriage1.ogg', 'sound/misc/carriage2.ogg', 'sound/misc/carriage3.ogg', 'sound/misc/carriage4.ogg'), 0, 0 ,0, 50)
 			ghost.paid = TRUE
+			coin_upkeep()
 			return
 		if(ghost.paid)
 			to_chat(ghost, "<br><font color=purple><span class='bold'>FURTHER PAYMENT WILL NOT CHANGE HER JUDGEMENT.</span></font>")

--- a/code/modules/underworld/underworld.dm
+++ b/code/modules/underworld/underworld.dm
@@ -106,7 +106,6 @@
 			to_chat(ghost, "<br><font color=purple><span class='bold'>THE TOLL IS PAID, THROUGH THE CARRIAGE THE UNDERMAIDEN WAITS.</span></font>")
 			user << sound(pick('sound/misc/carriage1.ogg', 'sound/misc/carriage2.ogg', 'sound/misc/carriage3.ogg', 'sound/misc/carriage4.ogg'), 0, 0 ,0, 50)
 			ghost.paid = TRUE
-			coin_upkeep()
 			return
 		if(ghost.paid)
 			to_chat(ghost, "<br><font color=purple><span class='bold'>FURTHER PAYMENT WILL NOT CHANGE HER JUDGEMENT.</span></font>")
@@ -163,14 +162,18 @@ GLOBAL_LIST_EMPTY(underworld_coins)
 
 /obj/item/underworld/coin/Destroy()
 	GLOB.underworld_coins -= src
+	coin_upkeep()
 	return ..()
 
 /obj/item/underworld/coin/pickup(mob/user)
 	..()
+	GLOB.underworld_coins -= src
+	coin_upkeep()
 	icon_state = "soultoken"
 
 /obj/item/underworld/coin/dropped(mob/user)
 	..()
+	GLOB.underworld_coins |= src
 	icon_state = "soultoken_floor"
 
 /proc/coin_upkeep()


### PR DESCRIPTION
The tolls have always tried to respawn if there was 3 or less in the underworld, but there was one scenario It wouldn't occur.
It previously only checked for tolls when a new ghost spawned in, but what if 20 ghosts spawn in, turn in all the tolls and no ghosts spawn in? That would cause no more tolls to appear.

Also secondly, now that ghosts can no longer knock each other out and steal tolls, there is a scenario where all the tolls can be held on afk ppl. 

This will hopefully resolve both, as it now checks on Destroy() aka the turn-in (to stop the ghost pileup and no new guys scenario) and when someone picks one up (to stop afk holdin)