### PR TITLE
Zombie rng re-adjustment

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -209,8 +209,7 @@
 							//addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon/human, werewolf_infect)), 3 MINUTES)
 				if(user.mind.has_antag_datum(/datum/antagonist/zombie))
 					if(!src.mind.has_antag_datum(/datum/antagonist/zombie))
-						if(prob(25)) // Delay is handled in zombie_infect anyways
-							H.zombie_infect()
+						H.zombie_infect_attempt()
 							//addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon/human, zombie_infect)), 3 MINUTES)
 
 	var/obj/item/grabbing/bite/B = new()

--- a/code/modules/antagonists/roguetown/villain/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie.dm
@@ -83,8 +83,17 @@
 	for(var/X in H.bodyparts)
 		var/obj/item/bodypart/BP = X
 		BP.update_disabled()
-	H.STASTR = rand(12,18)
-	H.STASPD = rand(5,7)
+
+	if(prob(8))
+		H.STASTR = 18
+	else
+		H.STASTR = rand(8,11)
+
+	if(prob(8))
+		H.STASPD = 7
+	else
+		H.STASPD = rand(2,4)
+
 	H.STAINT = 1
 
 
@@ -176,26 +185,29 @@
 
 //This occurs when one zombie infects a living human, going into instadeath from here is kind of shit and confusing
 //We instead just transform at the end
-/mob/living/carbon/human/proc/zombie_infect()
-	if(!mind)
+/mob/living/carbon/human/proc/zombie_infect_attempt()
+	if(prob(7)) // Do you prefer if(prob(93)) return?
+		if(!mind)
+			return
+		if(mind.has_antag_datum(/datum/antagonist/vampirelord))
+			return
+		if(mind.has_antag_datum(/datum/antagonist/zombie))
+			return
+		if(mind.has_antag_datum(/datum/antagonist/werewolf))
+			return
+		var/datum/antagonist/zombie/new_antag = new /datum/antagonist/zombie()
+		mind.add_antag_datum(new_antag)
+		if(stat != DEAD)
+			to_chat(src, "<span class='danger'>I feel horrible... REALLY horrible after that...</span>")
+			if(getToxLoss() >= 75 && blood_volume)
+				mob_timers["puke"] = world.time
+				vomit(1, blood = TRUE)
+			sleep(1 MINUTES) //you get a minute
+			flash_fullscreen("redflash3")
+			to_chat(src, "<span class='danger'>It hurts... Is this really the end for me...</span>")
+			emote("scream") // heres your warning to others bro
+			Knockdown(1)
+			new_antag.wake_zombie(TRUE)
+			//death()
+	else
 		return
-	if(mind.has_antag_datum(/datum/antagonist/vampirelord))
-		return
-	if(mind.has_antag_datum(/datum/antagonist/zombie))
-		return
-	if(mind.has_antag_datum(/datum/antagonist/werewolf))
-		return
-	var/datum/antagonist/zombie/new_antag = new /datum/antagonist/zombie()
-	mind.add_antag_datum(new_antag)
-	if(stat != DEAD)
-		to_chat(src, "<span class='danger'>I feel horrible... REALLY horrible after that...</span>")
-		if(getToxLoss() >= 75 && blood_volume)
-			mob_timers["puke"] = world.time
-			vomit(1, blood = TRUE)
-		sleep(1 MINUTES) //you get a minute
-		flash_fullscreen("redflash3")
-		to_chat(src, "<span class='danger'>It hurts... Is this really the end for me...</span>")
-		emote("scream") // heres your warning to others bro
-		Knockdown(1)
-		new_antag.wake_zombie(TRUE)
-		//death()

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -412,8 +412,7 @@
 					//addtimer(CALLBACK(C, TYPE_PROC_REF(/mob/living/carbon/human, werewolf_infect)), 3 MINUTES)
 			if(user.mind.has_antag_datum(/datum/antagonist/zombie))
 				var/mob/living/carbon/human/H = C
-				if(prob(25)) //Delay is handled in zombie infect anyways
-					H.zombie_infect()
+				H.zombie_infect_attempt()
 					//addtimer(CALLBACK(C, TYPE_PROC_REF(/mob/living/carbon/human, zombie_infect)), 3 MINUTES)
 				if(C.stat)
 					if(istype(limb_grabbed, /obj/item/bodypart/head))


### PR DESCRIPTION
Zombies have become a problem as of today apparently, when in prior times it was paladins. This attempts to bring them down a bit so people flock to the next option.

Zombie infect chance is brought down to 7% from 25%
Zombie strength is brought down to a rng range of 8-11, with a 5% chance to be at 18 instead of the previous 12-18.
Zombie speed is brought down to a rng range of 2-4, with a 5% chance to be at 7 instead of the previous 5-7.