### PR TITLE
Gives gravediggers the poor coin pouch instead of empty pouch

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
@@ -28,7 +28,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/roguekey/graveyard
-	beltr = /obj/item/storage/belt/rogue/pouch
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backr = /obj/item/rogueweapon/shovel
 	if(H.gender == FEMALE)
 		pants = null


### PR DESCRIPTION
Gives gravediggers the poor coin pouch instead of empty pouch. It helps them bury the dead.