### PR TITLE
AGhost Protection

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -378,15 +378,19 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		if(!ghost.can_reenter_corpse)
 			log_admin("[key_name(usr)] re-entered corpse")
 			message_admins("[key_name_admin(usr)] re-entered corpse")
-		var/mob/living/M = ghost.mind.current
-		var/datum/status_effect/incapacitating/sleeping/S = M.IsSleeping()
-		if(S && !M.IsKnockdown() && !M.IsStun() && !M.IsParalyzed()) // Wake them up unless they're asleep for another reason
-			M.remove_status_effect(S)
-			M.set_resting(FALSE, TRUE)
+		if(istype(ghost.mind.current, /mob/living))
+			var/mob/living/M = ghost.mind.current
+			var/datum/status_effect/incapacitating/sleeping/S = M.IsSleeping()
+			if(S && !M.IsKnockdown() && !M.IsStun() && !M.IsParalyzed()) // Wake them up unless they're asleep for another reason
+				M.remove_status_effect(S)
+				M.set_resting(FALSE, TRUE)
+			M.density = initial(M.density)
+			M.invisibility = initial(M.invisibility)
+		else
+			var/mob/M = ghost.mind.current
+			M.invisibility = initial(M.invisibility)
+			M.density = initial(M.density)
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
-		ghost.mind.current.invisibility = 0
-		if(!istype(M, /mob/living/carbon/spirit))
-			ghost.mind.current.density = 1
 		ghost.reenter_corpse()
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Admin Reenter") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(isnewplayer(mob))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -385,7 +385,8 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 			M.set_resting(FALSE, TRUE)
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
 		ghost.mind.current.invisibility = 0
-		ghost.mind.current.density = 1
+		if(!istype(M, /mob/living/carbon/spirit))
+			ghost.mind.current.density = 1
 		ghost.reenter_corpse()
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Admin Reenter") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(isnewplayer(mob))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -378,6 +378,11 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		if(!ghost.can_reenter_corpse)
 			log_admin("[key_name(usr)] re-entered corpse")
 			message_admins("[key_name_admin(usr)] re-entered corpse")
+		var/mob/living/M = ghost.mind.current
+		var/datum/status_effect/incapacitating/sleeping/S = M.IsSleeping()
+		if(S && !M.IsKnockdown() && !M.IsStun() && !M.IsParalyzed()) // Wake them up unless they're asleep for another reason
+			M.remove_status_effect(S)
+			M.set_resting(FALSE, TRUE)
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
 		ghost.mind.current.invisibility = 0
 		ghost.mind.current.density = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -379,6 +379,8 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 			log_admin("[key_name(usr)] re-entered corpse")
 			message_admins("[key_name_admin(usr)] re-entered corpse")
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
+		ghost.mind.current.invisibility = 0
+		ghost.mind.current.density = 1
 		ghost.reenter_corpse()
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Admin Reenter") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(isnewplayer(mob))
@@ -391,6 +393,8 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		log_admin("[key_name(usr)] admin ghosted.")
 		message_admins("[key_name_admin(usr)] admin ghosted.")
 		var/mob/body = mob
+		body.invisibility = INVISIBILITY_MAXIMUM
+		body.density = 0
 		body.ghostize(1)
 		if(body && !body.key)
 			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus


### PR DESCRIPTION
Staff can get robbed of all their items when they aghost to deal with an issue for too long. This is a quick fix that makes their character invisible and passable so that they won't get robbed and can safely leave to deal with issues.