### PR TITLE
Prince and Squire balance

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -42,10 +42,12 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.change_stat("perception", 1)
-			H.change_stat("strength", -3)
-			H.change_stat("endurance", -1)
+			H.change_stat("strength", 1)
+			H.change_stat("endurance", -2)
+			H.change_stat("intelligence", 1)
 			H.change_stat("constitution", 1)
 			H.change_stat("speed", 1)
+		ADD_TRAIT(H, RTRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	else
 		beltl = /obj/item/roguekey/manor
 		head = /obj/item/clothing/head/roguetown/hennin
@@ -61,7 +63,8 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
 			H.change_stat("perception", 2)
 			H.change_stat("endurance", -2)
-			H.change_stat("strength", -4)
+			H.change_stat("intelligence", 2)
+			H.change_stat("strength", -1)
 			H.change_stat("constitution", 1)
 			H.change_stat("speed", 2)		
 	ADD_TRAIT(H, RTRAIT_NOBLE, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -43,6 +43,7 @@
 			H.change_stat("strength", 1)
 			H.change_stat("perception", 1)
 			H.change_stat("constitution", 1)
+			H.change_stat("endurance", 1)
 			H.change_stat("speed", 1)
 	if(H.gender == FEMALE)
 		pants = /obj/item/clothing/under/roguetown/tights
@@ -67,4 +68,7 @@
 			H.change_stat("strength", 1)
 			H.change_stat("perception", 1)
 			H.change_stat("constitution", 1)
+			H.change_stat("endurance", 1)
 			H.change_stat("speed", 1)
+	
+	ADD_TRAIT(H, RTRAIT_HEAVYARMOR, TRAIT_GENERIC)


### PR DESCRIPTION
Aims to improve the experience of the prince and squire roles. In my eyes these roles are those with "potential" but lack the skill and equipment to fill that potential. Resulting in the need to train and make an arrangement with the blacksmith.

In its current iteration, the prince has a whopping -5 strength (-3 from the role and -2 from young age modifier). This has to be an oversight because they usually start with the strength of an elf woman. This runs into the problem of wielding swords as most are 5-7 strength, I've played princes with just 4-5 strength and kept dropping my weapon.

I would imagine the prince/princess to be well nourished and given the best education. For the princess, it would be realistic to keep the gender disparity in skills/stats due to nobility values. It would still be possible to train her up.

Slight squire skill buff, as looking at the description they are essentially the best handpicked peasants to undergo training. They are likely to be acquainted with arduous labor.

Heavy armor skill given, as pretty much all the nobility and keep guards are given. I would imagine they would be given proper training on using heavy armor (except the princess, hopefully the code will only apply just to the male).