### PR TITLE
Rogue and Ranger world amount limits, slight Ranger Buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
@@ -6,6 +6,7 @@
 	allowed_sexes = list("male", "female")
 	allowed_races = list("Dwarf","Dwarf")
 	outfit = /datum/outfit/job/roguetown/adventurer/dranger
+	maxchosen = 5
 
 /datum/outfit/job/roguetown/adventurer/dranger/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -35,5 +36,6 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)	
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.change_stat("perception", 3)
 	ADD_TRAIT(H, RTRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -12,6 +12,8 @@
 	 "Tiefling",
 	"Aasimar")
 	outfit = /datum/outfit/job/roguetown/adventurer/ranger
+	pickprob = 40
+	maxchosen = 15
 
 /datum/outfit/job/roguetown/adventurer/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -24,6 +26,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -12,6 +12,8 @@
 	"Tiefling",
 	"Aasimar")
 	outfit = /datum/outfit/job/roguetown/adventurer/rogue
+	pickprob = 25
+	maxchosen = 10
 
 /datum/outfit/job/roguetown/adventurer/rogue/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
Rogue is limited to 10 possible in any given round, with a 25% of the option even being in someone's list
Ranger is limited to 15 possible in any given round with a 40% chance of even being in someone's list
Dwarf Ranger is limited to 5 possible in any given round, will probably always appear.

Both rangers also gain 2 sneaking.