### PR TITLE
Lets Pilgrims pick all available worker classes (not adventurers), rare classes still RNG-Based.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(billagerspawns)
 				classamt = 999
 		// Increase available classes for pilgrims
 		if(ispilgrim)
-			classamt = 999
+			classamt = 15
 		if(isvillager)
 			GLOB.billagerspawns |= H
 #ifdef TESTSERVER

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -44,6 +44,9 @@ GLOBAL_LIST_EMPTY(billagerspawns)
 		if(M.client)
 			if(M.client.patreonlevel() >= 1)
 				classamt = 999
+		// Increase available classes for pilgrims
+		if(ispilgrim)
+			classamt = 999
 		if(isvillager)
 			GLOB.billagerspawns |= H
 #ifdef TESTSERVER


### PR DESCRIPTION
As title!
90% of the time, only the most basic classes will be available for pilgrims. The rarer classes have a pickprob variable set in place, which only when rolled will make it so that specific class will appear, and they are also limited to avoid many people being that class.