### PR TITLE
Removes adventurer cap

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -5,8 +5,8 @@ GLOBAL_LIST_EMPTY(billagerspawns)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 75
-	spawn_positions = 75
+	total_positions = -1
+	spawn_positions = -1
 	allowed_races = list("Humen",
 	"Elf",
 	"Half-Elf",


### PR DESCRIPTION
Title. Adventurers are now uncapped just like pilgrims. Since pilgrims now have completely different classes from adventurers, I feel like both should be uncapped so that the player can choose between being combat focused or job focused.