### PR TITLE
Stops the Balloon From Selling Mammons

### DIFF
--- a/code/modules/roguetown/roguemachine/merchant.dm
+++ b/code/modules/roguetown/roguemachine/merchant.dm
@@ -79,9 +79,7 @@
 			if(!E)
 				continue
 			for(var/obj/I in T)
-				if(I.anchored)
-					continue
-				if(!isturf(I.loc))
+				if(I.anchored || !isturf(I.loc) || istype(I, /obj/item/roguecoin))
 					continue
 				var/prize = I.get_real_price() - (I.get_real_price() * SStreasury.queens_tax)
 				if(prize >= 1)


### PR DESCRIPTION
The balloon will suck your money up and send part of it it to taxes if you leave mammons near it, that's silly and it probably shouldn't do that.