### PR TITLE
PQ requirement for town smithy

### DIFF
--- a/code/modules/jobs/job_types/roguetown/serfs/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/serfs/blacksmith.dm
@@ -18,6 +18,7 @@
 	outfit = /datum/outfit/job/roguetown/armorsmith
 	display_order = JDO_ARMORER
 	give_bank_account = 11
+	min_pq = 1
 
 /datum/outfit/job/roguetown/armorsmith/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -75,6 +76,7 @@
 
 	outfit = /datum/outfit/job/roguetown/weaponsmith
 	display_order = JDO_WSMITH
+	min_pq = 1
 
 /datum/outfit/job/roguetown/weaponsmith/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
Adds a PQ requirement of 1 to town armorsmith and weaponsmith to put new players into the apprentice slots until they actually learn the role.