### PR TITLE
Allows shylocks to dispense single coins again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,5 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 !/config/title_screens/images/exclude
 /data/triumphs.sav
 config/admins.txt
+cfg/admin.txt
+config/admins.txt

--- a/code/modules/roguetown/roguemachine/money.dm
+++ b/code/modules/roguetown/roguemachine/money.dm
@@ -146,7 +146,7 @@ GLOBAL_VAR(moneymaster)
 			if("BRONZE")
 				zenars = budget
 				type_to_spawn = /obj/item/roguecoin/copper
-		if(zenars <= 1)
+		if(zenars < 1)
 			return
 		var/obj/item/roguecoin/G = new type_to_spawn(T)
 		G.set_quantity(floor(zenars))


### PR DESCRIPTION
Fixes #194

There was an early return if the coins to withdraw were `<= 1` rather than `< 1`