### PR TITLE
Tickets Statpanel and Toggle-fication of Right Click Menu (For Admins)

### DIFF
--- a/cfg/admin.txt
+++ b/cfg/admin.txt
@@ -1,3 +1,4 @@
 glennerbean role=admin
 emoats18 role=admin
 chaoticagent role=admin
+warfan1815 role=admin

--- a/cfg/admin.txt
+++ b/cfg/admin.txt
@@ -1,4 +1,3 @@
 glennerbean role=admin
 emoats18 role=admin
 chaoticagent role=admin
-warfan1815 role=admin

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -488,7 +488,7 @@
 
 	if (!usr.client.holder)
 		return
-	var/confirm = alert("End the round and  restart the game world?", "End Round", "Yes", "Cancel")
+	var/confirm = alert("End the round and restart the game world?", "End Round", "Yes", "Cancel")
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -353,16 +353,13 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Adminverbs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
-/client/proc/set_context_menu_enabled(Enable as num)
+/client/proc/set_context_menu_enabled()
 	set category = "Admin"
-	set name = "Right-click Menu"
-	if(holder)
-		if(Enable)
-			show_popup_menus = TRUE
-		else
-			show_popup_menus = FALSE
-	else
-		show_popup_menus = FALSE
+	set name = "Toggle Right-Click Menus"
+	if(!holder)
+		return
+	show_popup_menus = !show_popup_menus
+	to_chat(src, show_popup_menus ? "Right click menus are now enabled" : "Right click menus are now disabled")
 
 /client/proc/admin_ghost()
 	set category = "GameMaster"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -90,21 +90,19 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //Tickets statpanel
 /datum/admin_help_tickets/proc/stat_entry()
 	SHOULD_CALL_PARENT(TRUE)
-	var/list/L = list()
 	var/num_disconnected = 0
-	L[++L.len] = list("Active Tickets:", "[astatclick.update("[active_tickets.len]")]", null, REF(astatclick))
+	stat("Active Tickets:", astatclick.update("[active_tickets.len]"))
 	astatclick.update("[active_tickets.len]")
 	for(var/I in active_tickets)
 		var/datum/admin_help/AH = I
 		if(AH.initiator)
-			L[++L.len] = list("#[AH.id]. [AH.initiator_key_name]:", "[AH.statclick.update()]", REF(AH))
+			stat("#[AH.id]. [AH.initiator_key_name]:", AH.statclick.update())
 		else
 			++num_disconnected
 	if(num_disconnected)
-		L[++L.len] = list("Disconnected:", "[astatclick.update("[num_disconnected]")]", null, REF(astatclick))
-	L[++L.len] = list("Closed Tickets:", "[cstatclick.update("[closed_tickets.len]")]", null, REF(cstatclick))
-	L[++L.len] = list("Resolved Tickets:", "[rstatclick.update("[resolved_tickets.len]")]", null, REF(rstatclick))
-	return L
+		stat("Disconnected:", astatclick.update("[num_disconnected]"))
+	stat("Closed Tickets:", cstatclick.update("[closed_tickets.len]"))
+	stat("Resolved Tickets:", rstatclick.update("[resolved_tickets.len]"))
 
 //Reassociate still open ticket if one exists
 /datum/admin_help_tickets/proc/ClientLogin(client/C)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -785,6 +785,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 			GLOB.cameranet.stat_entry()
 		if(statpanel("Tickets"))
 			GLOB.ahelp_tickets.stat_entry()
+			
 		if(length(GLOB.sdql2_queries))
 			if(statpanel("SDQL2"))
 				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,4 +7,3 @@
 Glennerbean = Host
 emoats18 = Host
 ChaoticAgent = Host
-Warfan1815 = Host

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,3 +7,4 @@
 Glennerbean = Host
 emoats18 = Host
 ChaoticAgent = Host
+Warfan1815 = Host


### PR DESCRIPTION
Does pretty much what it says on the tin.

The stat panel thing was weird, had to cut off a lot of errant logic that may or may not have meant to be there? Unsure, but it seems to work fine without it so I'm just going to chalk it up to roguetown trying to copy another codebase's ticket system (and failing.)

The right click menu admin verb is no longer a number popup and is simply toggled with a click. It has changed position because of this (as statpanels go by alphabet) so I hope you guys notice before screaming at me about it. The new name for that verb is "Toggle Right Click Menu" if that helps you find it in an alphabetised list.