### PR TITLE
Peasant rebel nerf

### DIFF
--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -286,6 +286,8 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampire Lord", "Extended", "
 					blockme = TRUE
 				if(rebelguy.assigned_role in GLOB.serf_positions)
 					blockme = TRUE
+				if(rebelguy.assigned_role in GLOB.allmig_positions)
+					blockme = TRUE
 				if(blockme)
 					continue
 				allantags -= rebelguy

--- a/code/modules/antagonists/roguetown/villain/peasantrebel.dm
+++ b/code/modules/antagonists/roguetown/villain/peasantrebel.dm
@@ -10,7 +10,7 @@
 	antag_hud_name = "rev"
 	var/datum/team/prebels/rev_team
 	show_in_roundend = FALSE
-	confess_lines = list("VIVA!", "DEATH TO THE NOBLES!")
+	confess_lines = list("VIVA!", "DEATH TO THE NOBLES!", "NO GODS, NO MASTERS!")
 	increase_votepwr = FALSE
 
 /datum/antagonist/prebel/examine_friendorfoe(datum/antagonist/examined_datum,mob/examiner,mob/examined)
@@ -40,6 +40,10 @@
 		if(new_owner.assigned_role in GLOB.noble_positions)
 			return FALSE
 		if(new_owner.assigned_role in GLOB.garrison_positions)
+			return FALSE
+		if(new_owner.assigned_role in GLOB.church_positions)
+			return FALSE
+		if(new_owner.assigned_role in GLOB.allmig_positions)
 			return FALSE
 		if(new_owner.unconvertable)
 			return FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(billagerspawns)
 /datum/job/roguetown/adventurer
 	title = "Adventurer"
 	flag = ADVENTURER
-	department_flag = PEASANTS
+	department_flag = ALLMIG
 	faction = "Station"
 	total_positions = 75
 	spawn_positions = 75


### PR DESCRIPTION
This should in theory prevent adventurers from being able to join the rebels (they normally make up the bulk of combat pawns) and also stops the church positions such as templars from joining. The rebellion should now be a church and nobility issue (atheist peasants). 

At the very least it will make the rebels be made of peasants/unwashed masses instead of gung-ho paladins/clerics/warriors.