### PR TITLE
Stop Bank Account Collisions

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -57,7 +57,7 @@
 				if(H.anti_magic_check())
 					to_chat(H, "<span class='warning'>I'm protected from the scepter.</span>")
 					return
-				if(!(H.real_name in SStreasury.bank_accounts))
+				if(!(H in SStreasury.bank_accounts))
 					to_chat(H, "<span class='warning'>I'm protected from the scepter.</span>")
 					return
 				H.electrocute_act(5, src)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -156,9 +156,9 @@
 
 	if(give_bank_account)
 		if(give_bank_account > 1)
-			SStreasury.create_bank_account(H.real_name, give_bank_account)
+			SStreasury.create_bank_account(H.ckey + H.real_name, give_bank_account)
 		else
-			SStreasury.create_bank_account(H.real_name)
+			SStreasury.create_bank_account(H.ckey + H.real_name)
 
 	if(show_in_credits)
 		SScrediticons.processing += H

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -156,9 +156,9 @@
 
 	if(give_bank_account)
 		if(give_bank_account > 1)
-			SStreasury.create_bank_account(H.ckey + H.real_name, give_bank_account)
+			SStreasury.create_bank_account(H, give_bank_account)
 		else
-			SStreasury.create_bank_account(H.ckey + H.real_name)
+			SStreasury.create_bank_account(H)
 
 	if(show_in_credits)
 		SScrediticons.processing += H

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -65,7 +65,7 @@
 //		else
 //			if(get_triumphs() > 0)
 //				tris2take += -1
-		if(real_name in SStreasury.bank_accounts)
+		if(H in SStreasury.bank_accounts)
 			for(var/obj/structure/roguemachine/camera/C in view(7, src))
 				var/area_name = A.name
 				var/texty = "<CENTER><B>Death of a Living Being</B><br>---<br></CENTER>"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,14 +1,6 @@
 
 /mob/living/carbon/human/proc/change_name(new_name)
-	if(real_name == new_name)
-		return
-	var/act
-	if(real_name in SStreasury.bank_accounts)
-		act = SStreasury.bank_accounts[real_name]
-		SStreasury.bank_accounts -= real_name
-	real_name = new_name
-	if(act)
-		SStreasury.create_bank_account(ckey + real_name, act)
+	return
 
 /mob/living/carbon/human/restrained(ignore_grab)
 	. = ((wear_armor && wear_armor.breakouttime) || ..())

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -1,6 +1,6 @@
 
 /mob/living/carbon/human/proc/change_name(new_name)
-	return
+	real_name = new_name
 
 /mob/living/carbon/human/restrained(ignore_grab)
 	. = ((wear_armor && wear_armor.breakouttime) || ..())

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -8,7 +8,7 @@
 		SStreasury.bank_accounts -= real_name
 	real_name = new_name
 	if(act)
-		SStreasury.create_bank_account(real_name, act)
+		SStreasury.create_bank_account(ckey + real_name, act)
 
 /mob/living/carbon/human/restrained(ignore_grab)
 	. = ((wear_armor && wear_armor.breakouttime) || ..())

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -11,8 +11,8 @@
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
-	if(H.real_name in SStreasury.bank_accounts)
-		var/amt = SStreasury.bank_accounts[H.real_name]
+	if(H in SStreasury.bank_accounts)
+		var/amt = SStreasury.bank_accounts[H]
 		if(!amt)
 			say("Your balance is nothing.")
 			return
@@ -28,7 +28,7 @@
 		var/selection = input(user, "Make a Selection", src) as null|anything in choicez
 		if(!selection)
 			return
-		amt = SStreasury.bank_accounts[H.real_name]
+		amt = SStreasury.bank_accounts[H]
 		var/mod = 1
 		if(selection == "GOLD")
 			mod = 10
@@ -38,13 +38,13 @@
 		coin_amt = round(coin_amt)
 		if(coin_amt < 1)
 			return
-		amt = SStreasury.bank_accounts[H.real_name]
+		amt = SStreasury.bank_accounts[H]
 		if(!Adjacent(user))
 			return
 		if((coin_amt*mod) > amt)
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
-		if(!SStreasury.withdraw_money_account(coin_amt*mod, H.real_name))
+		if(!SStreasury.withdraw_money_account(coin_amt*mod, H))
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return
 		budget2change(coin_amt*mod, user, selection)
@@ -53,7 +53,7 @@
 		icon_state = "atm-b"
 		H.flash_fullscreen("redflash3")
 		playsound(H, 'sound/combat/hits/bladed/genstab (1).ogg', 100, FALSE, -1)
-		SStreasury.create_bank_account(H.ckey + H.real_name)
+		SStreasury.create_bank_account(H)
 		spawn(5)
 			say("New account created.")
 			playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
@@ -70,8 +70,8 @@
 	if(ishuman(user))
 		if(istype(P, /obj/item/roguecoin))
 			var/mob/living/carbon/human/H = user
-			if(H.real_name in SStreasury.bank_accounts)
-				SStreasury.generate_money_account(P.get_real_price(), H.real_name)
+			if(H in SStreasury.bank_accounts)
+				SStreasury.generate_money_account(P.get_real_price(), H)
 				qdel(P)
 				playsound(src, 'sound/misc/coininsert.ogg', 100, FALSE, -1)
 				return

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -53,7 +53,7 @@
 		icon_state = "atm-b"
 		H.flash_fullscreen("redflash3")
 		playsound(H, 'sound/combat/hits/bladed/genstab (1).ogg', 100, FALSE, -1)
-		SStreasury.create_bank_account(H.real_name)
+		SStreasury.create_bank_account(H.ckey + H.real_name)
 		spawn(5)
 			say("New account created.")
 			playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -122,7 +122,7 @@
 				switch(select)
 					if("To Bank")
 						var/mob/living/carbon/human/H = usr
-						SStreasury.generate_money_account(secret_budget, H.real_name)
+						SStreasury.generate_money_account(secret_budget, H)
 						secret_budget = 0
 					if("Direct")
 						if(secret_budget > 0)

--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -124,7 +124,6 @@
 				D.withdraw_price = newtax
 	if(href_list["givemoney"])
 		var/X = locate(href_list["givemoney"])
-		to_chat(world, "[X]")
 		if(!X)
 			return
 		for(var/mob/living/A in SStreasury.bank_accounts)

--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -123,8 +123,11 @@
 					scom_announce("The withdraw price for [D.name] was decreased.")
 				D.withdraw_price = newtax
 	if(href_list["givemoney"])
-		var/X = href_list["givemoney"]
-		for(var/A in SStreasury.bank_accounts)
+		var/X = locate(href_list["givemoney"])
+		to_chat(world, "[X]")
+		if(!X)
+			return
+		for(var/mob/living/A in SStreasury.bank_accounts)
 			if(A == X)
 				var/newtax = input(usr, "How much to give [X]", src) as null|num
 				if(!usr.canUseTopic(src, BE_CLOSE) || locked)
@@ -138,8 +141,10 @@
 				SStreasury.give_money_account(newtax, A)
 				break
 	if(href_list["fineaccount"])
-		var/X = href_list["fineaccount"]
-		for(var/A in SStreasury.bank_accounts)
+		var/X = locate(href_list["fineaccount"])
+		if(!X)
+			return
+		for(var/mob/living/A in SStreasury.bank_accounts)
 			if(A == X)
 				var/newtax = input(usr, "How much to fine [X]", src) as null|num
 				if(!usr.canUseTopic(src, BE_CLOSE) || locked)
@@ -174,7 +179,7 @@
 			return
 		for(var/mob/living/carbon/human/H in GLOB.human_list)
 			if(H.job == job_to_pay)
-				SStreasury.give_money_account(amount_to_pay, H.real_name)
+				SStreasury.give_money_account(amount_to_pay, H)
 	return attack_hand(usr)
 
 /obj/structure/roguemachine/steward/proc/do_import(datum/roguestock/D,number)
@@ -215,23 +220,23 @@
 		if(TAB_MAIN)
 			contents += "<center>NERVE MASTER<BR>"
 			contents += "--------------<BR>"
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_BANK]'>\[Bank\]</a><BR>"
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_STOCK]'>\[Stockpile\]</a><BR>"
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_IMPORT]'>\[Import\]</a><BR>"
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_BOUNTIES]'>\[Bounties\]</a><BR>"
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_LOG]'>\[Log\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_BANK]'>\[Bank\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_STOCK]'>\[Stockpile\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_IMPORT]'>\[Import\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_BOUNTIES]'>\[Bounties\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_LOG]'>\[Log\]</a><BR>"
 			contents += "</center>"
 		if(TAB_BANK)
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
 			contents += "<center>Bank<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m</center><BR>"
-			contents += "<a href='?src=[REF(src)];payroll=1'>\[Pay by Class\]</a><BR><BR>"
-			for(var/A in SStreasury.bank_accounts)
-				contents += "[A] - [SStreasury.bank_accounts[A]]m<BR>"
-				contents += "<a href='?src=[REF(src)];givemoney=[A]'>\[Give Money\]</a> <a href='?src=[REF(src)];fineaccount=[A]'>\[Fine Account\]</a><BR><BR>"
+			contents += "<a href='?src=\ref[src];payroll=1'>\[Pay by Class\]</a><BR><BR>"
+			for(var/mob/living/A in SStreasury.bank_accounts)
+				contents += "[A.real_name] - [SStreasury.bank_accounts[A]]m<BR>"
+				contents += "<a href='?src=\ref[src];givemoney=\ref[A]'>\[Give Money\]</a> <a href='?src=\ref[src];fineaccount=\ref[A]'>\[Fine Account\]</a><BR><BR>"
 		if(TAB_STOCK)
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
 			contents += "<center>Stockpile<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m<BR>"
@@ -241,14 +246,14 @@
 				contents += "[A.name]<BR>"
 				contents += "[A.desc]<BR>"
 				contents += "Stockpiled Amount: [A.held_items]<BR>"
-				contents += "Bounty Price: <a href='?src=[REF(src)];setbounty=[REF(A)]'>[A.payout_price]</a><BR>"
-				contents += "Withdraw Price: <a href='?src=[REF(src)];setprice=[REF(A)]'>[A.withdraw_price]</a><BR>"
+				contents += "Bounty Price: <a href='?src=\ref[src];setbounty=\ref[A]'>[A.payout_price]</a><BR>"
+				contents += "Withdraw Price: <a href='?src=\ref[src];setprice=\ref[A]'>[A.withdraw_price]</a><BR>"
 				contents += "Demand: [A.demand2word()]<BR>"
 				if(A.importexport_amt)
-					contents += "<a href='?src=[REF(src)];import=[REF(A)]'>\[Import [A.importexport_amt] ([A.get_import_price()])\]</a> <a href='?src=[REF(src)];export=[REF(A)]'>\[Export [A.importexport_amt] ([A.get_export_price()])\]</a> <BR>"
-				contents += "<a href='?src=[REF(src)];togglewithdraw=[REF(A)]'>\[[A.withdraw_disabled ? "Enable" : "Disable"] Withdrawing\]</a><BR><BR>"
+					contents += "<a href='?src=\ref[src];import=\ref[A]'>\[Import [A.importexport_amt] ([A.get_import_price()])\]</a> <a href='?src=\ref[src];export=\ref[A]'>\[Export [A.importexport_amt] ([A.get_export_price()])\]</a> <BR>"
+				contents += "<a href='?src=\ref[src];togglewithdraw=\ref[A]'>\[[A.withdraw_disabled ? "Enable" : "Disable"] Withdrawing\]</a><BR><BR>"
 		if(TAB_IMPORT)
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
 			contents += "<center>Imports<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m<BR>"
@@ -259,9 +264,9 @@
 				contents += "[A.desc]<BR>"
 				if(!A.stable_price)
 					contents += "Demand: [A.demand2word()]<BR>"
-				contents += "<a href='?src=[REF(src)];import=[REF(A)]'>\[Import [A.importexport_amt] ([A.get_import_price()])\]</a><BR><BR>"
+				contents += "<a href='?src=\ref[src];import=\ref[A]'>\[Import [A.importexport_amt] ([A.get_import_price()])\]</a><BR><BR>"
 		if(TAB_BOUNTIES)
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
 			contents += "<center>Bounties<BR>"
 			contents += "--------------<BR>"
 			contents += "Treasury: [SStreasury.treasury_value]m<BR>"
@@ -271,11 +276,11 @@
 				contents += "[A.desc]<BR>"
 				contents += "Total Collected: [A.held_items]<BR>"
 				if(A.percent_bounty)
-					contents += "Bounty Price: <a href='?src=[REF(src)];setbounty=[REF(A)]'>[A.payout_price]%</a><BR><BR>"
+					contents += "Bounty Price: <a href='?src=\ref[src];setbounty=\ref[A]'>[A.payout_price]%</a><BR><BR>"
 				else
-					contents += "Bounty Price: <a href='?src=[REF(src)];setbounty=[REF(A)]'>[A.payout_price]</a><BR><BR>"
+					contents += "Bounty Price: <a href='?src=\ref[src];setbounty=\ref[A]'>[A.payout_price]</a><BR><BR>"
 		if(TAB_LOG)
-			contents += "<a href='?src=[REF(src)];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
 			contents += "<center>Log<BR>"
 			contents += "--------------</center><BR><BR>"
 			for(var/i = SStreasury.log_entries.len to 1 step -1)

--- a/code/modules/roguetown/roguemachine/submission.dm
+++ b/code/modules/roguetown/roguemachine/submission.dm
@@ -19,8 +19,8 @@
 			say("Single item entries only. Please unstack.")
 			return
 		if(istype(P, /obj/item/roguecoin))
-			if(H.real_name in SStreasury.bank_accounts)
-				SStreasury.generate_money_account(P.get_real_price(), H.real_name)
+			if(H in SStreasury.bank_accounts)
+				SStreasury.generate_money_account(P.get_real_price(), H)
 				qdel(P)
 				playsound(src, 'sound/misc/coininsert.ogg', 100, FALSE, -1)
 				return
@@ -51,7 +51,7 @@
 					playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 					flick("submit_anim",src)
 					if(amt)
-						if(!SStreasury.give_money_account(amt, H.real_name, "+[amt] from [R.name] bounty"))
+						if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty"))
 							say("No account found. Submit your fingers to a shylock for inspection.")
 					return
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

As documented in #270, bank accounts only base themselves on the mob's real_name. This changes that to use a reference to their mob instead, making it impossible for another person to have a collision.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People can't rob others that share their name.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
