### PR TITLE
New Guard Starter Kits

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -47,6 +47,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/sword
 	backr = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(/obj/item/rope/chain = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -69,7 +69,7 @@
 	beltr = /obj/item/rogueweapon/mace/cudgel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	if(is_bowman)
 		backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 		beltr = /obj/item/quiver/bolts //replaces mace

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -37,3 +37,33 @@
 /obj/structure/closet/crate/chest/steward/wheat/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/snacks/grown/wheat(src)
+
+/datum/roguestock/import/bogguard
+	name = "Bog Guard Equipment Crate"
+	desc = "Starting kit for a new Bog Guard."
+	item_type = /obj/structure/closet/crate/chest/steward/bogguard
+	export_price = 50
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/bogguard/Initialize()
+	. = ..()
+	new /obj/item/clothing/cloak/stabard/bog(src)
+	new /obj/item/keyring/guard(src)
+	new /obj/item/clothing/suit/roguetown/armor/gambeson(src)
+	new /obj/item/rogueweapon/mace/cudgel(src)
+	new /obj/item/rope/chain(src)
+	
+/datum/roguestock/import/townguard
+	name = "Town Guard Equipment Crate"
+	desc = "Starting kit for a new Town Guard."
+	item_type = /obj/structure/closet/crate/chest/steward/townguard
+	export_price = 50
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/townguard/Initialize()
+	. = ..()
+	new /obj/item/clothing/cloak/stabard/guard(src)
+	new /obj/item/keyring/guard(src)
+	new /obj/item/clothing/suit/roguetown/armor/gambeson(src)
+	new /obj/item/rogueweapon/mace/cudgel(src)
+	new /obj/item/rope/chain(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows the Steward to import equipment starter kits for newly recruited Bog Guards and Town Guards. Contains their respective tabards for easy identification, guards key, cudgel, basic armor, and chains to make arrests.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gives Steward more work to contribute and provides a way to have new recruits to be identifiable other than examining.  

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
