### PR TITLE
wild game attracted by bags of bait will no longer consume the entire bag

### DIFF
--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -79,6 +79,10 @@
 						if(T)
 							var/mob/M = pickweight(attracted_types)
 							new M(T)
+							if(prob(66))
+								new /obj/item/storage/roguebag/crafted(T)
+							else
+								new /obj/item/natural/cloth(T)
 							qdel(src)
 					else
 						qdel(src)


### PR DESCRIPTION
## About The Pull Request

see title.

There's a 1 in 3 chance that the bag will be torn to scraps, but otherwise it'll make it a lot less annoying to craft bait to... actually do your job as a hunter.

## Why It's Good For The Game

Less pain for trying to play as a non-adventurer. Recrafting bags constantly is kind of a chore.

I did test this in game and it did function as far as I could tell, spawning both cloth and sacks when the bait was used.
Absolutely 100% a better way I could've coded this to work, I'm just a salt coder lmao.
