### PR TITLE
Steward can import healing potions, removes grain import

### DIFF
--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -27,17 +27,6 @@
 	locked = TRUE
 	masterkey = TRUE
 
-/datum/roguestock/import/wheat
-	name = "Crate of Wheat"
-	desc = "Wheat."
-	item_type = /obj/structure/closet/crate/chest/steward/wheat
-	export_price = 40
-	importexport_amt = 1
-
-/obj/structure/closet/crate/chest/steward/wheat/PopulateContents()
-	for(var/i in 1 to 5)
-		new /obj/item/reagent_containers/food/snacks/grown/wheat(src)
-
 /datum/roguestock/import/bogguard
 	name = "Bog Guard Equipment Crate"
 	desc = "Starting kit for a new Bog Guard."
@@ -67,3 +56,18 @@
 	new /obj/item/clothing/suit/roguetown/armor/gambeson(src)
 	new /obj/item/rogueweapon/mace/cudgel(src)
 	new /obj/item/rope/chain(src)
+
+/datum/roguestock/import/redpotion
+	name = "Crate of Health Potions"
+	desc = "Red that keeps men alive."
+	item_type = /obj/structure/closet/crate/chest/steward/redpotion
+	export_price = 100
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/redpotion/Initialize()
+	. = ..()
+	new /obj/item/reagent_containers/glass/bottle/rogue/healthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/healthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/healthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/healthpot(src)
+	new /obj/item/reagent_containers/glass/bottle/rogue/healthpot(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Steward will be able to import 5 health potions for 100 mammons. Let's survive this rebellion, guards!!

Removes import of grain as he can already import it in other Tab.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

