### PR TITLE
You can only behead by attacking neck

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2268,7 +2268,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/easy_dismember = HAS_TRAIT(H, TRAIT_EASYDISMEMBER) || affecting.rotted
 	if(prob(probability) || (easy_dismember && prob(probability))) //try twice
 		if(affecting.brute_dam > 0)
-			if(affecting.dismember(I.damtype))
+			if(affecting.dismember(I.damtype, selzone))
 				bloody = 1
 				I.add_mob_blood(H)
 				user.update_inv_hands()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -84,6 +84,8 @@
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
 		return FALSE
+	if(body_zone == BODY_ZONE_HEAD && (zone_precise != BODY_ZONE_PRECISE_NECK))
+		return FALSE
 	if(skeletonized)
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -19,8 +19,9 @@
 		return FALSE
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
-		if(zone_precise != BODY_ZONE_PRECISE_NECK)
-			return FALSE
+		return FALSE
+	if(body_zone == BODY_ZONE_HEAD && (zone_precise != BODY_ZONE_PRECISE_NECK))
+		return FALSE
 	if(C.status_flags & GODMODE)
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
@@ -83,8 +84,6 @@
 		return FALSE
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
-		return FALSE
-	if(body_zone == BODY_ZONE_HEAD && (zone_precise != BODY_ZONE_PRECISE_NECK))
 		return FALSE
 	if(skeletonized)
 		return FALSE

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -1,6 +1,6 @@
 
 /obj/item/bodypart/proc/can_dismember(obj/item/I)
-	if(dismemberable)
+	if(dismemberable || /obj/item/bodypart/head)
 		return TRUE
 
 /obj/item/bodypart/proc/can_disable(obj/item/I)
@@ -14,12 +14,13 @@
 'sound/combat/dismemberment/dismem (6).ogg')
 
 //Dismember a limb
-/obj/item/bodypart/proc/dismember(dam_type = BRUTE)
+/obj/item/bodypart/proc/dismember(dam_type = BRUTE, zone_precise)
 	if(!owner)
 		return FALSE
 	var/mob/living/carbon/C = owner
 	if(!dismemberable)
-		return FALSE
+		if(zone_precise != BODY_ZONE_PRECISE_NECK)
+			return FALSE
 	if(C.status_flags & GODMODE)
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -1,6 +1,6 @@
 
 /obj/item/bodypart/proc/can_dismember(obj/item/I)
-	if(dismemberable || /obj/item/bodypart/head)
+	if(dismemberable)
 		return TRUE
 
 /obj/item/bodypart/proc/can_disable(obj/item/I)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -13,7 +13,6 @@
 	px_y = -8
 	stam_damage_coeff = 1
 	max_stamina_damage = 100
-	dismemberable = FALSE
 
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/obj/item/organ/brain/brain = null //The brain organ

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -13,6 +13,7 @@
 	px_y = -8
 	stam_damage_coeff = 1
 	max_stamina_damage = 100
+	dismemberable = FALSE
 
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/obj/item/organ/brain/brain = null //The brain organ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Change so players need to go for neck - harder to hit part - to behead someone.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Beheading was too easy and required little weapon skill and stats.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
