### PR TITLE
Armor crit resist fix

### DIFF
--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -373,7 +373,7 @@
 		return
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		if(H.checkcritarmor(src, bclass))
+		if(H.checkcritarmor(zone_precise, bclass))
 			return FALSE
 	//try limbsmash here, return
 	//try dismember here, return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Armor now properly checks for what it should protect.
Example: Helmet with no mouth protection won't give you crit protection on mouth.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
