### PR TITLE
Make bow craftable

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -231,3 +231,9 @@
 
 /obj/item/rogueweapon/shovel/small/crafted
 	sellprice = 5
+
+/datum/crafting_recipe/roguetown/bow
+	name = "bow"
+	result = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+	reqs = list(/obj/item/grown/log/tree = 1,
+			/obj/item/rope = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

-Added Bow recipes in roguecrafting/items.dm

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

As of now, bows seemed to be completely absent from any recipes file, meaning it was impossible to get your hands on one if you didn't spawn with it, despite the arrows for it being as cheap as dirt. Opens up a bit the range game to none range starting classes and allows for a cheap but accesible way to fight crossbow spam in the PvP areas.