### PR TITLE
Spell wound healing adjustment

### DIFF
--- a/code/modules/spells/roguetown/cleric.dm
+++ b/code/modules/spells/roguetown/cleric.dm
@@ -88,7 +88,7 @@
 			if(affecting)
 				if(affecting.heal_damage(20, 20, 0, null, FALSE))
 					C.update_damage_overlays()
-				if(affecting.heal_wounds(50))
+				if(affecting.heal_wounds(10))
 					C.update_damage_overlays()
 		else
 			target.adjustBruteLoss(-5)
@@ -136,7 +136,7 @@
 			if(affecting)
 				if(affecting.heal_damage(50, 50, 0, null, FALSE))
 					C.update_damage_overlays()
-				if(affecting.heal_wounds(50))
+				if(affecting.heal_wounds(20))
 					C.update_damage_overlays()
 		else
 			target.adjustBruteLoss(-50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Make spells not so powerful, they are great at healing damage, regenerating blood and closing wounds.
After all the changes to wounds (and health potion), we finally can make spells worse in wound healing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes needles and medicine skill matter more, wounds no longer being a joke when clerics are around.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
