### PR TITLE
Fixes dezombification

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie.dm
@@ -33,7 +33,6 @@
 		TRAIT_SHOCKIMMUNE,
 		TRAIT_SPELLCOCKBLOCK,
 		TRAIT_ZOMBIE_SPEECH,
-		TRAIT_LANGUAGE_BARRIER,
 	)
 
 /datum/antagonist/zombie/examine_friendorfoe(datum/antagonist/examined_datum,mob/examiner,mob/examined)

--- a/code/modules/antagonists/roguetown/villain/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie.dm
@@ -82,6 +82,8 @@
 		zombie.STASPD = STASPD
 		zombie.STAINT = STAINT
 		zombie.remove_client_colour(/datum/client_colour/monochrome)
+		for(var/trait in traits_applied)
+			REMOVE_TRAIT(zombie, trait, "[type]")
 	return ..()
 
 /datum/antagonist/zombie/proc/transform_zombie()


### PR DESCRIPTION
At some point i forgot to remove the traits of zombies when the antag datum got removed, so every "cured" zombie was stuck in this permanent nightmare scenario of being a zombie but also not.

Removes TRAIT_LANGUAGE_BARRIER from zombies, because I think it's funnier if all their speech just gets replaced with "UUHHHHHHHHH..."