### PR TITLE
Templar and paladin differentiation - Both spawn with the t0 spell of their chosen patron, can unlock t1 spell and nothing else

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -26,8 +26,7 @@
 /datum/devotion/cleric_holder/proc/check_devotion(req)
 	if(abs(req) <= devotion)
 		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /datum/devotion/cleric_holder/proc/update_devotion(dev_amt, prog_amt)
 	var/datum/patrongods/P = patron
@@ -43,19 +42,22 @@
 		if(CLERIC_T0)
 			if(progression >= CLERIC_REQ_1)
 				level = CLERIC_T1
-				usr.mind.AddSpell(new P.t1)
+				if(!usr.mind.has_spell(P.t1))
+					usr.mind.AddSpell(new P.t1)
 				return
 		if(CLERIC_T1)
 			if(progression >= CLERIC_REQ_2)
 				level = CLERIC_T2
-				usr.mind.AddSpell(new P.t2)
+				if(!usr.mind.has_spell(P.t2))
+					usr.mind.AddSpell(new P.t2)
 				return
 		if(CLERIC_T2)
 			if(progression >= CLERIC_REQ_3)
 				level = CLERIC_T3
-				usr.mind.AddSpell(new P.t3)
+				if(!usr.mind.has_spell(P.t3))
+					usr.mind.AddSpell(new P.t3)
 				return
-		if(CLERIC_T3) // already maxed out
+		else // already maxed out
 			return
 
 // Devotion Debugs

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -8,7 +8,7 @@
 	"Tiefling",
 	"Aasimar")
 	outfit = /datum/outfit/job/roguetown/adventurer/paladin
-	allowed_patrons = list("Astrata", "Dendor", "Necra")
+	allowed_patrons = list("Astrata", "Dendor", "Necra", "Pestra")
 
 /datum/outfit/job/roguetown/adventurer/paladin/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -76,5 +76,5 @@
 	C.max_devotion = 250
 	C.update_devotion(50, 50)
 	C.holder_mob = H
-	C.grant_spells(H)
+	C.grant_spells_templar(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -158,18 +158,10 @@
 		var/datum/devotion/cleric_holder/holder = new /datum/devotion/cleric_holder(recruit, recruit.PATRON)
 		holder.holder_mob = recruit
 		//Max devotion limit - Templars are stronger but cannot pray to gain more abilities
-		holder.max_devotion = 200
+		holder.max_devotion = 250
 		holder.update_devotion(50, 50)
+		holder.grant_spells_templar(recruit)
 	recruit.verbs |= list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	var/static/list/templar_spells = list(
-		/obj/effect/proc_holder/spell/invoked/lesser_heal, 
-		/obj/effect/proc_holder/spell/targeted/churn, 
-		/obj/effect/proc_holder/spell/targeted/burialrite,
-	)
-	for(var/spell in templar_spells)
-		if(recruit.mind.has_spell(spell))
-			continue
-		recruit.mind.AddSpell(new spell)
 
 /obj/effect/proc_holder/spell/self/convertrole/monk
 	name = "Recruit Acolyte"

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -13,7 +13,6 @@
 	min_pq = 2
 	total_positions = 2
 	spawn_positions = 2
-	spells = list(/obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/targeted/churn, /obj/effect/proc_holder/spell/targeted/burialrite)
 	display_order = JDO_TEMPLAR
 	give_bank_account = TRUE
 
@@ -59,7 +58,8 @@
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/datum/devotion/cleric_holder/C = new /datum/devotion/cleric_holder(H, H.PATRON)
 	//Max devotion limit - Templars are stronger but cannot pray to gain more abilities
-	C.max_devotion = 200
+	C.max_devotion = 250
 	C.update_devotion(50, 50)
 	C.holder_mob = H
+	C.grant_spells_templar(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -9,6 +9,7 @@
 	allowed_races = list("Humen",
 	"Tiefling",
 	"Aasimar")
+	allowed_patrons = list("Astrata", "Dendor", "Necra", "Pestra")
 	outfit = /datum/outfit/job/roguetown/templar
 	min_pq = 2
 	total_positions = 2
@@ -18,7 +19,30 @@
 
 /datum/outfit/job/roguetown/templar/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+	var/allowed_patrons = list("Astrata", "Dendor", "Necra", "Pestra")
+	
+	var/datum/patrongods/ourpatron
+	if(istype(H.PATRON, /datum/patrongods))
+		ourpatron = H.PATRON
+
+	if(!ourpatron || !(ourpatron.name in allowed_patrons))
+		var/list/datum/patrongods/possiblegods = list()
+		for(var/datum/patrongods/P in GLOB.patronlist)
+			if(P.name in allowed_patrons)
+				possiblegods |= P
+		ourpatron = pick(possiblegods)
+		H.PATRON = ourpatron
+		to_chat(H, "<span class='warning'> My patron had not endorsed my practices in my younger years. I've since grown acustomed to [H.PATRON].")
+	
+	switch(ourpatron.name)
+		if("Astrata")
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+		if("Dendor")
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+		if("Necra")
+			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+		if("Pestra")
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	pants = /obj/item/clothing/under/roguetown/tights/black

--- a/code/modules/spells/roguetown/cleric.dm
+++ b/code/modules/spells/roguetown/cleric.dm
@@ -55,6 +55,18 @@
 			continue
 		H.mind.AddSpell(new spell)
 
+/datum/devotion/cleric_holder/proc/grant_spells_templar(mob/living/carbon/human/H)
+	if(!H || !H.mind)
+		return
+
+	var/datum/patrongods/A = H.PATRON
+	var/spelllist = list(A.t0)
+	level = CLERIC_T0
+	for(var/spell in spelllist)
+		if(H.mind.has_spell(spell))
+			continue
+		H.mind.AddSpell(new spell)
+
 // General
 /obj/effect/proc_holder/spell/invoked/lesser_heal
 	name = "Lesser Miracle"


### PR DESCRIPTION
## About The Pull Request

Read the title!

## Why It's Good For The Game

Templars/paladins having so many spells is kind of bullshit and doesn't jive with how progression works for acolytes.
This change ensures both are primarily combat classes, and having spells (related to their patron) is just a wee bonus.
