### PR TITLE
Underworld Changes

### DIFF
--- a/code/modules/mob/living/carbon/spirit/spirit.dm
+++ b/code/modules/mob/living/carbon/spirit/spirit.dm
@@ -47,7 +47,9 @@
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
 	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_GENERIC)
-	name = pick("Wanderer", "Traveler", "Pilgrim", "Mourner", "Sorrowful", "Forlorn", "Regretful", "Piteous", "Rueful", "Dejected")
+	var/first_part = pick("Sorrowful", "Forlorn", "Regretful", "Piteous", "Rueful", "Dejected", "Desolate", "Mournful", "Melancholic", "Woeful")
+	var/second_part = pick("Wanderer", "Traveler", "Pilgrim", "Vagabond", "Nomad", "Wayfarer", "Spirit", "Specter", "Wraith", "Phantom")
+	name = first_part + " " + second_part
 
 	//initialize limbs
 	create_bodyparts()
@@ -105,6 +107,15 @@
 	if(statpanel("Status"))
 		stat(null, "Intent: [a_intent]")
 		stat(null, "Move Mode: [m_intent]")
+	return
+
+/mob/living/carbon/spirit/toggle_move_intent(mob/user) // Override so they can't run.
+	return
+
+/mob/living/carbon/spirit/toggle_rogmove_intent(intent, silent = FALSE) // Override so they can't run.
+	return
+
+/mob/living/carbon/spirit/mmb_intent_change(input as text) // There's no need for them to change MMB intents
 	return
 
 /mob/living/carbon/spirit/returntolobby()

--- a/code/modules/underworld/underworld.dm
+++ b/code/modules/underworld/underworld.dm
@@ -201,7 +201,7 @@ GLOBAL_VAR_INIT(underworld_coins, 0)
 	should_track = FALSE
 
 /proc/coin_upkeep()
-	if(GLOB.underworld_coins < 3)
+	if(GLOB.underworld_coins < 8)
 		for(var/obj/effect/landmark/underworldcoin/B in GLOB.landmarks_list)
 			new /obj/item/underworld/coin(B.loc)
 	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds more variety to spirit names so that when people ahelp "Dejected is [doing bad thing]" there won't be 20 spirits with that exact name. 100 different name combinations are possible.

Removes the ability for spirits to change movement speed or middle mouse intents.

Drastically reduces the number of tolls that need to be destroyed before triggering a respawn. Tolls will respawn when they hit 7 left.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Easier identification of specific spirits, easier for them to find tolls, should kill toll stealing except for real this time.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
