### PR TITLE
nerfs bailiff and councilor 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -10,6 +10,7 @@
 	"Half-Elf",
 	"Aasimar")
 	allowed_sexes = list(MALE, FEMALE)
+	allowed_ages = list(AGE_OLD) // you would think that a "bailiff" position would require them to be old.
 	display_order = JDO_BAILIFF
 	tutorial = "You judge the common folk and their wrongdoings if necessary. You help plan with the Councillors or the King on any new issues, laws, judgings, and construction that are required to adapt to the world. You serve on the same level as Sheriff, however unlike him you are from Petty Nobility. You have two assistant Councillors that may serve as jurors to assist you in your job. You are required to collect taxes for the King, judge people, make sure the town and manor are not in decay, and to help plan or construct new buildings. You are allowed some command over Guards, however it is not the focus of your job unless special circumstances are to change this."
 	whitelist_req = FALSE
@@ -28,7 +29,7 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	beltl = /obj/item/keyring/sheriff
-	beltr = /obj/item/rogueweapon/mace/steel
+	beltr = /obj/item/rogueweapon/mace //what the fuck? the steel mace does 40 damage btw, don't give them the 40 damage weapon roundstart.
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/bailiff
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
@@ -36,21 +37,19 @@
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
-		H.change_stat("strength", 5)
-		H.change_stat("perception", 2)
+		H.change_stat("strength", 3)
 		H.change_stat("intelligence", 3)
-		H.change_stat("constitution", 1)
-		H.change_stat("endurance", 1)
-		H.change_stat("speed", 1)
-		H.change_stat("fortune", 1)
+		H.change_stat("constitution", 2)
+		H.change_stat("endurance", 2)
+		H.change_stat("speed", -2)
 	ADD_TRAIT(H, RTRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, RTRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell

--- a/code/modules/jobs/job_types/roguetown/nobility/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/councillor.dm
@@ -35,13 +35,11 @@
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/councillor
 	backpack_contents = list(/obj/item/keyring/councillor = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE) //aren't they suppose to be booknerds?
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-		H.change_stat("intelligence", 3)
+		H.change_stat("intelligence", 4)
 		H.change_stat("constitution", 1)
-		H.change_stat("fortune", 2)
 


### PR DESCRIPTION
since I know a CERTAIN SOMEONE will never revert bailiff and councilors, I will seek to make them not as godtier anymore.


bailiff got 40 damage mace roundstart? with 5 strength and 1 fortune, even sheriff isn't this good.
councilors got 2 fortune and monk unarmed stats with insane athletics
![headdev](https://github.com/Blackstone-SS13/BLACKSTONE/assets/76455911/47248e94-7d0e-48ab-ad48-bbf4458f6f6c)
this is your headdev btw.



