### PR TITLE
Un-Nukes miracle healing

### DIFF
--- a/code/modules/spells/roguetown/cleric.dm
+++ b/code/modules/spells/roguetown/cleric.dm
@@ -100,7 +100,7 @@
 			if(affecting)
 				if(affecting.heal_damage(20, 20, 0, null, FALSE))
 					C.update_damage_overlays()
-				if(affecting.heal_wounds(10))
+				if(affecting.heal_wounds(30))
 					C.update_damage_overlays()
 		else
 			target.adjustBruteLoss(-5)
@@ -148,7 +148,7 @@
 			if(affecting)
 				if(affecting.heal_damage(50, 50, 0, null, FALSE))
 					C.update_damage_overlays()
-				if(affecting.heal_wounds(20))
+				if(affecting.heal_wounds(40))
 					C.update_damage_overlays()
 		else
 			target.adjustBruteLoss(-50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
As title!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Un-wrecks miracle healing:
Original: 50 wound healing for both lesser and normal miracle
First nerf: 10 wound heal for lesser and 20 for normal
This: 30 lesser, 40 normal
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
