### PR TITLE
Gives townguard a leather helmet on spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -58,6 +58,7 @@
 
 /datum/outfit/job/roguetown/guardsman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
+	head = /obj/item/clothing/head/roguetown/helmet/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	cloak = /obj/item/clothing/cloak/stabard/guard
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/merc


### PR DESCRIPTION
## About The Pull Request

Gives town guards a basic leather helmet instead of nothing

## Why It's Good For The Game

Having no head protection makes them very weak, but leather isn't too much of a buff

![2](https://github.com/Blackstone-SS13/BLACKSTONE/assets/15787530/218dbba9-e0fe-411b-a6b4-1c830b03d2e1)
