### PR TITLE
Gives zombies TRAIT_BLOODLOSS_IMMUNE

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie.dm
@@ -41,6 +41,7 @@
 		TRAIT_SPELLCOCKBLOCK,
 		TRAIT_ZOMBIE_SPEECH,
 		TRAIT_ZOMBIE_IMMUNE,
+		TRAIT_BLOODLOSS_IMMUNE,
 	)
 	/// Traits applied to the owner when we are cured and turn into just "rotmen"
 	var/static/list/traits_rotman = list(


### PR DESCRIPTION
This was an unintended regression when I last touched zombies. They were never meant to be vulnerable to blood loss.