### PR TITLE
[/tg/station sends its regards] Make client rendering less ass (Re-adds client fps game preference, sets default to 100fps)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 20//0 is sync
+	var/clientfps = 100//0 is sync
 
 	var/parallax
 
@@ -668,7 +668,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<b>Income Updates:</b> <a href='?_src_=prefs;preference=income_pings'>[(chat_toggles & CHAT_BANKCARD) ? "Allowed" : "Muted"]</a><br>"
 			dat += "<br>"
 */
-//			dat += "<b>FPS:</b> <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
+			dat += "<b>FPS:</b> <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
 /*
 			dat += "<b>Parallax (Fancy Space):</b> <a href='?_src_=prefs;preference=parallaxdown' oncontextmenu='window.location.href=\"?_src_=prefs;preference=parallaxup\";return false;'>"
 			switch (parallax)


### PR DESCRIPTION
Not sure what the hell is going on here but client fps isn't known to impact the server load at all so there isn't any reason to disable and gimp it like it was.

100 was chosen because 100 fps renders better than 60fps or 120fps in byond because of rounding with milliseconds that puts 60fps out of lockstep with the server's 20fps that doesn't happen when client fps evenly multiples with both 1000ms and the server's 20fps. This matches the default everywhere else.

from /tg/cord: 
![image](https://github.com/Blackstone-SS13/BLACKSTONE/assets/7069733/b3402676-a3b1-4cff-a806-12a7eaeb9d16)


This PR is untested.