### PR TITLE
Vampire antag adjustments

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -334,11 +334,11 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 					if(T.get_lumcount() > 0.15)
 						if(!isspawn)
 							to_chat(H, "<span class='warning'>Astrata spurns me! I must get out of her rays!</span>") // VLord is more punished for daylight excursions.
-							sleep(100)
 							var/turf/N = H.loc
 							if(N.can_see_sky())
 								if(N.get_lumcount() > 0.15)
-									H.dust()
+									H.fire_act(3)
+									handle_vitae(-500)
 							to_chat(H, "<span class='warning'>That was too close. I must avoid the sun.</span>")
 						else if (isspawn && !disguised)
 							H.fire_act(1,5)
@@ -1229,14 +1229,14 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	releasedrain = 100
 	chargedrain = 0
 	chargetime = 0
-	range = 15
+	range = 10
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	chargedloop = null
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/blood
 	antimagic_allowed = TRUE
-	charge_max = 5 SECONDS
+	charge_max = 10 SECONDS
 	include_user = 0
 	max_targets = 1
 
@@ -1259,26 +1259,26 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		if(willroll >= bloodroll)
 			to_chat(user, "I fail to ensnare their mind.")
 			if(willroll - bloodroll >= 3)
-				to_chat(L, "I feel like something is messing with my head.")
+				to_chat(L, "I feel like someone or something unholy is messing with my head. I should get out of here!")
 				var/holyskill = user.mind.get_skill_level(/datum/skill/magic/holy)
 				var/arcaneskill = user.mind.get_skill_level(/datum/skill/magic/arcane)
-				if(holyskill + arcaneskill >= 3)
-					to_chat(L, "I feel like the magic came from [user]")
+				if(holyskill + arcaneskill >= 1)
+					to_chat(L, "I feel like the unholy magic came from [user]. I should use my magic or miracles on them.")
 
 /obj/effect/proc_holder/spell/targeted/transfix/master
 	name = "Subjugate"
 	overlay_state = "transfixmaster"
-	releasedrain = 200
+	releasedrain = 1000
 	chargedrain = 0
 	chargetime = 0
-	range = 15
+	range = 10
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	chargedloop = null
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/blood
 	antimagic_allowed = TRUE
-	charge_max = 5 SECONDS
+	charge_max = 30 SECONDS
 	include_user = 0
 	max_targets = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Increases the cooldown and reduced range of transfix and subjugation-aoe transfix. Makes it clearer when you are targeted by transfix and anyone with a modicum of holy skill or arcane knowledge will know who used it on you. Also changes the dusting/death from sunlight for vampire lord and instead makes it similar to vampire spawn suffers but more extreme. Vampire lord still has no disguise so they will still need to be cautious in sunlight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think it strikes a better balance rather than outright removing the abilities. People are getting more familiar with vampire antags that bring more to light about the unbalanced shit. Many ahelps involve the day 1 death from vampire lord from accidently walking into the sunlight.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
