### PR TITLE
Training cap. #NoTrainoids

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -260,12 +260,13 @@
 	skill_experience[S] = max(0, skill_experience[S] + amt) //Prevent going below 0
 	var/old_level = known_skills[S]
 	switch(skill_experience[S])
-		if(SKILL_EXP_LEGENDARY to INFINITY)
+		//Manual growth capped to Skilled. We hate trainoids.
+		/*if(SKILL_EXP_LEGENDARY to INFINITY)
 			known_skills[S] = SKILL_LEVEL_LEGENDARY
 		if(SKILL_EXP_MASTER to SKILL_EXP_LEGENDARY)
 			known_skills[S] = SKILL_LEVEL_MASTER
 		if(SKILL_EXP_EXPERT to SKILL_EXP_MASTER)
-			known_skills[S] = SKILL_LEVEL_EXPERT
+			known_skills[S] = SKILL_LEVEL_EXPERT*/
 		if(SKILL_EXP_JOURNEYMAN to SKILL_EXP_EXPERT)
 			known_skills[S] = SKILL_LEVEL_JOURNEYMAN
 		if(SKILL_EXP_APPRENTICE to SKILL_EXP_JOURNEYMAN)
@@ -277,6 +278,9 @@
 	if(isnull(old_level) || known_skills[S] == old_level)
 		return //same level or we just started earning xp towards the first level.
 	if(silent)
+		return	
+	if(known_skills[S] >= SKILL_LEVEL_JOURNEYMAN)
+		to_chat(current, "<span class='nicegreen'>I have learned all I could about [S.name]!</span>")
 		return
 	if(known_skills[S] >= old_level)
 		if(known_skills[S] > old_level)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -882,7 +882,7 @@
 					if(prob(probby) && !L.has_status_effect(/datum/status_effect/debuff/trainsleep) && !user.buckled)
 						user.visible_message("<span class='info'>[user] trains on [src]!</span>")
 						var/amt2raise = L.STAINT/2
-						if(user.mind.get_skill_level(W.associated_skill) >= 3)
+						if(user.mind.get_skill_level(W.associated_skill) >= SKILL_LEVEL_APPRENTICE)
 							to_chat(user, "<span class='warning'>I've learned all I can from doing this, it's time for the real thing.</span>")
 							amt2raise = 0
 						if(amt2raise > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Practice dummy training capped to Average.
- All other skill gains capped to Skilled.

<img src="https://github.com/Blackstone-SS13/BLACKSTONE/assets/62253058/b02d38d6-3fcc-42ee-a531-57c487b2eabe" width="500">

<img src="https://github.com/Blackstone-SS13/BLACKSTONE/assets/62253058/4d76cc76-667c-4429-8199-525922c7bce6" width="400">

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

- Establishes a very clear, well defined (and easily modified through code), balance to all the classes and their respective skills in Blackstone. Allowing the community to see which classes are actually too strong or too weak now that statistics arent skewed by trainoids.
- Nerfs no lifeing on this server in favor of class "consciousness". Knights will be knights, adventurers will be adventurers and beggars will be beggars. Everyone should know their strengths and weaknesses and play accordingly, not simply grind until those weaknesses don't exist.


