### PR TITLE
Vault Economy Tweaks

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -28,6 +28,8 @@ SUBSYSTEM_DEF(treasury)
 	var/treasury_value = 0
 	var/list/bank_accounts = list()
 	var/list/stockpile_datums = list()
+	var/multiple_item_penalty = 0.66
+	var/interest_rate = 0.25
 	var/next_treasury_check = 0
 	var/list/log_entries = list()
 
@@ -50,6 +52,7 @@ SUBSYSTEM_DEF(treasury)
 /datum/controller/subsystem/treasury/fire(resumed = 0)
 	if(world.time > next_treasury_check)
 		next_treasury_check = world.time + rand(5 MINUTES, 8 MINUTES)
+		var/list/stockpile_items = list()
 		if(SSticker.current_state == GAME_STATE_PLAYING)
 			for(var/datum/roguestock/X in stockpile_datums)
 				if(!X.stable_price && !X.transport_item)
@@ -61,19 +64,25 @@ SUBSYSTEM_DEF(treasury)
 		var/amt_to_generate = 0
 		for(var/obj/item/I in A)
 			if(!isturf(I.loc))
-				return
-			if(I.get_real_price() <= 0)
-				return
+				continue
+			if(I.get_real_price() <= 0 || istype(I, /obj/item/roguecoin))
+				continue
 			if(!I.submitted_to_stockpile)
 				I.submitted_to_stockpile = TRUE
-			amt_to_generate += (I.get_real_price()*0.25)
+			if(I.type in stockpile_items)
+				stockpile_items[I.type] *= multiple_item_penalty
+			else
+				stockpile_items[I.type] = I.get_real_price()
+			amt_to_generate += (stockpile_items[I.type]*interest_rate)
 		amt_to_generate = amt_to_generate - (amt_to_generate * queens_tax)
 		amt_to_generate = round(amt_to_generate)
 		give_money_treasury(amt_to_generate, "wealth horde")
+		var/people_told = 0
 		for(var/mob/living/carbon/human/X in GLOB.human_list)
-			if(X.job == "King" || X.job == "Queen")
+			switch(X.job)
+			if("King", "Queen", "Steward", "Clerk")
 				send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
-				return
+			
 
 /datum/controller/subsystem/treasury/proc/create_bank_account(name, initial_deposit)
 	if(!name)

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -80,8 +80,11 @@ SUBSYSTEM_DEF(treasury)
 		var/people_told = 0
 		for(var/mob/living/carbon/human/X in GLOB.human_list)
 			switch(X.job)
-			if("King", "Queen", "Steward", "Clerk")
-				send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
+				if("King", "Queen", "Steward", "Clerk")
+					people_told += 1
+					send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
+					if(people_told > 3)
+						return
 			
 
 /datum/controller/subsystem/treasury/proc/create_bank_account(name, initial_deposit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

If an item worth 0 was placed into the vault, the vault would stop processing early and not pay out.

Adds a penalty for multiple of the same item type in the treasury, encouraging stewards to diversify the items they place inside. Each item of the same type will earn 33% cumulative less worth per duplicate, with the first earning full value, then each subsequent losing 33%.

Also, Stewards and Clerks will be alerted to the treasury accruing value.

Coins in the treasury will not accrue interest.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Encourages Stewards to diversify investments and not spam one item into the vault. Doing so will lead to severe drops in value.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
