### PR TITLE
[FIX] Remove "suspiciouspicious" 

### DIFF
--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -58,8 +58,6 @@
 		"rizzard": "charmer",
 		"rizzler": "charmer",
 		"gyatt": "buttocks",
-		"sussy": "suspicious",
-		"sus": "suspicious",
 		"baka": "nimrod",
 		"ligma": "leprosy",
 		"griddy": "charm",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the "sus" and "sussy" accent autoreplacer.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Nobody says "sus" in 2024, yet a lot of people say suspicious or otherwise use words with "sus" in it. This anti-sus measure hurts a lot more than it helps as it prevents you from saying a lot of words.
