### PR TITLE
Restart vote can't be called until 2:00 instead of 1:40

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,7 +11,7 @@
 //0 test
 //12 minutes norma
 //#define ROUNDTIMERBOAT (300 MINUTES)
-#define INITIAL_ROUND_TIMER (99 MINUTES)
+#define INITIAL_ROUND_TIMER (150 MINUTES)
 #define ROUND_EXTENSION_TIME (30 MINUTES)
 //180 norma
 //60 test

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,7 +11,7 @@
 //0 test
 //12 minutes norma
 //#define ROUNDTIMERBOAT (300 MINUTES)
-#define INITIAL_ROUND_TIMER (150 MINUTES)
+#define INITIAL_ROUND_TIMER (120 MINUTES)
 #define ROUND_EXTENSION_TIME (30 MINUTES)
 //180 norma
 //60 test


### PR DESCRIPTION
## About The Pull Request

Makes it so the restart vote can't be called before two and a half hours, instead of the one hour 39 minutes it is currently 

## Why It's Good For The Game

Longer rounds
