### PR TITLE
Townguard PQ from -4 to 3

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -21,7 +21,7 @@
 
 	outfit = /datum/outfit/job/roguetown/guardsman
 	give_bank_account = 16
-	min_pq = -4
+	min_pq = 3
 
 	/// Chance to be spawned as a bowman instead
 	var/bowman_chance = 35


### PR DESCRIPTION
Town Guard PQ bumped up from -4 to 3 to make griefers spend a bit more time prepping.
Secondly now the bog guard exists for low quality guard anyways.

Also emoney asked for this so im speedmerging it