### PR TITLE
Allow players to check their PQ, notify them if it changes.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -280,6 +280,7 @@
 	if(!amt2change && !raisin)
 		return
 	adjust_playerquality(amt2change, ckey, admin, raisin)
+	to_chat(M.client, "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">Your PQ has been adjusted by [amt2change] by [admin] for reason: [raisin]</span></span>")
 
 /datum/admins/proc/access_news_network() //MARKER
 	set category = "Fun"

--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -192,6 +192,10 @@
 	if(!amt2change && !raisin)
 		return
 	adjust_playerquality(amt2change, theykey, src.ckey, raisin)
+	for(var/client/C in GLOB.clients) // I hate this, but I'm not refactoring the cancer above this point.
+		if(lowertext(C.key) == lowertext(theykey))
+			to_chat(C, "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">Your PQ has been adjusted by [amt2change] by [key] for reason: [raisin]</span></span>")
+			return
 
 /proc/add_commend(key, giver)
 	if(!giver || !key)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1472,9 +1472,7 @@ Slots: [job.spawn_positions]</span>
 		user.show_triumphs_list()
 
 	else if(href_list["preference"] == "playerquality")
-		var/amt = get_commends(user.ckey)
-		to_chat(user, "PlayerQuality represents the aggregate data collected automatically by the game to determine your reliability level as a RolePlayer. <font color='blue'>You have earned [amt] commendations from other players.</font>")
-
+		check_pq_menu(user.ckey)
 
 	else if(href_list["preference"] == "keybinds")
 		switch(href_list["task"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When an admin changes a player's PQ, they will be automatically notified of the change, who did it, and the reason given.

On the character creation screen, clicking the PQ link will show the player their full PQ history.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

PQ transparency for players.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
