### PR TITLE
Log pickpocket attempts, tell players PQ reqs for roles

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -408,11 +408,17 @@
 							V.dropItemToGround(picked)
 							put_in_active_hand(picked)						
 							to_chat(src, "<span class='green'>I stole [picked]!</span>")
+							V.log_message("has had \the [picked] stolen by [key_name(U)]", LOG_ATTACK, color="black")
+							U.log_message("has stolen \the [picked] from [key_name(U)]", LOG_ATTACK, color="black")
 						else
 							to_chat(src, "<span class='warning'>I didn't find anything there. Perhaps I should look elsewhere.</span>")
-					if(stealroll <= 4)	
+					if(stealroll <= 4)
+						V.log_message("has had an attempted pickpocket by [key_name(U)]", LOG_ATTACK, color="black")
+						U.log_message("has attempted to pickpocket [key_name(U)]", LOG_ATTACK, color="black")
 						to_chat(V, "<span class='danger'>Someone tried pickpocketing me!</span>")
 					if(stealroll < targetperception)
+						V.log_message("has had an attempted pickpocket by [key_name(U)]", LOG_ATTACK, color="black")
+						U.log_message("has attempted to pickpocket [key_name(U)]", LOG_ATTACK, color="black")
 						to_chat(src, "<span class='danger'>I failed to pick the pocket!</span>")
 					changeNext_move(mmb_intent.clickcd)
 				return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -986,7 +986,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				HTML += "<font color=#a59461>[used_name]</font></td> <td> </td></tr>"
 				continue
 			if(!job.required && !isnull(job.min_pq) && (get_playerquality(user.ckey) < job.min_pq))
-				HTML += "<font color=#a59461>[used_name]</font></td> <td> </td></tr>"
+				HTML += "<font color=#a59461>[used_name] (Min PQ: [job.min_pq])</font></td> <td> </td></tr>"
 				continue
 			if(!(user.client.prefs.age in job.allowed_ages))
 				HTML += "<font color=#a36c63>[used_name]</font></td> <td> </td></tr>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Pickpocket attempts will now be logged to help admins investigate kills as a result of someone having their things stolen.

Players with insufficient PQ will be told the PQ requirements for roles they can't play.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pickpocketing is a common cause for people to kill each other, there was no way for admins to verify if a pickpocket occurred.

Players will have a better idea of how much PQ they need to play a role.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
