### PR TITLE
Seizing the means of adminwho() (Available to players now)

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -99,10 +99,7 @@
 	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
-	
-	if(!check_rights(R_ADMIN))
-		to_chat(src, "You do not have the rights to use this command.")
-		return
+
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows us to see which admins are ignoring ahelps, shitters beware :)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Self-explanatory. The restriction is random af and I don't see a justifiable reason for it to exist. We should all be able to see which admins are online. At least now I know how to call out for ignoring ahelps if they're smart enough to avoid announcing their presence.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
