### PR TITLE
Added noequipment variant for non-AI skeletons.

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -47,7 +47,7 @@
 	for(var/obj/item/bodypart/B in src.bodyparts)
 		B.skeletonize()
 	// src.remove_all_languages()
-	// removing this because i wanna actually be able to talk as a skellybones fella
+	// uncomment this to prohibit skeletons from knowing or speaking any languages. This is commented to allow skeletons to be the main subject of admin events. (eg: skeleton traders, skeletons concealing their bones and blending in with the kingdom society, the underworld bar skeletons, skeletons telling skeleton jokes)
 	var/obj/item/organ/eyes/eyes = src.getorganslot(ORGAN_SLOT_EYES)
 	if(eyes)
 		eyes.Remove(src,1)
@@ -108,4 +108,7 @@
 		r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 
 /mob/living/carbon/human/species/skeleton/npc/no_equipment
+    skel_outfit = null
+
+/mob/living/carbon/human/species/skeleton/no_equipment
     skel_outfit = null


### PR DESCRIPTION
(also modified comment to elaborate on why skeletons have language.)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Simple addition, defining a subtype of non-npc skeletons that do not spawn with items. Useful for events where player skeletons are dressed up by admins or simply spawned and left without even the most bare**bones.** of attire.
![euanbonk](https://github.com/Blackstone-SS13/BLACKSTONE/assets/46800751/bc798dd8-1464-4092-8710-3c96f4e948ba)
heh.. sorry i couldn't stop myself.

## Why It's Good For The Game

This very minor addition makes events that use player skeletons significantly easier to manage and prepare.
Not much **byond** that.
![image](https://github.com/Blackstone-SS13/BLACKSTONE/assets/46800751/9c60d333-d411-4217-8db4-82de27712127)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
