### PR TITLE
Player Book PR adjustments and fixes

### DIFF
--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -393,7 +393,7 @@
 	base_icon_state = "basic_book"
 	override_find_book = TRUE
 	
-/obj/item/book/rogue/playerbook/Initialize(loc, in_round_player_generated, var/mob/living/in_round_player_mob, player_book_text)
+/obj/item/book/rogue/playerbook/Initialize(loc, in_round_player_generated, var/mob/living/in_round_player_mob, text)
 	. = ..()
 	is_in_round_player_generated = in_round_player_generated
 	if(is_in_round_player_generated)
@@ -401,6 +401,7 @@
 		player_book_title = dd_limittext(capitalize(sanitize_hear_message(input(in_round_player_mob, "What title do you want to give the book? (max 42 characters)", "Title", "Unknown"))), MAX_NAME_LEN)
 		player_book_author = "[dd_limittext(sanitize_hear_message(input(in_round_player_mob, "Do you want to preface your author name with an author title? (max 42 characters)", "Author Title", "")), MAX_NAME_LEN)] [in_round_player_mob.real_name]"
 		player_book_icon = book_icons[input(in_round_player_mob, "Choose a book style", "Book Style") as anything in book_icons]
+		player_book_text = text
 		message_admins("[player_book_author_ckey]([in_round_player_mob.real_name]) has generated the player book: [player_book_title]")
 	else
 		player_book_titles = SSlibrarian.pull_player_book_titles()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -27,6 +27,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/cmd_admin_say,
 	/client/proc/deadmin,				/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/set_context_menu_enabled,
+	/client/proc/delete_player_book,
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -814,8 +815,9 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		to_chat(src, "<span class='interface'>Ending DISABLED.</span>")
 
 /client/proc/delete_player_book()
+	set name = "Database Delete Player Book"
 	set category = "Admin"
-	set name = "Delete Player Made Book"
+	set desc = ""
 	if(!holder)
 		return
 	if(SSlibrarian.del_player_book(input(src, "What is the book file you want to delete? (spaces and other characters are their url encode versions for the file name, so for example spaces are +)")))

--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -90,10 +90,13 @@
 
 /proc/create_random_books_rogue(amount = 2, location)
 	var/list/possible_books = subtypesof(/obj/item/book/rogue/)
+	var/list/player_book_titles = SSlibrarian.pull_player_book_titles()
 	for(var/b in 1 to amount)
-		if(prob(50))
-			var/obj/item/book/rogue/playerbook/newbook = new /obj/item/book/rogue/playerbook(src)
-			if(prob(50))
+		if(prob(0.1))
+			new /obj/item/book_crafting_kit(location)
+		if(prob(clamp(length(player_book_titles), 10, 90)))
+			var/obj/item/book/rogue/playerbook/newbook = new /obj/item/book/rogue/playerbook(location)
+			if(prob(33))
 				newbook.pages = SSlibrarian.file2playerbook("ruined")["text"]
 		else
 			var/obj/item/book/rogue/addition = pick(possible_books)
@@ -104,7 +107,7 @@
 			if(istype(newbook, /obj/item/book/rogue/bibble))
 				qdel(newbook)
 				continue
-			if(prob(50))
+			if(prob(33))
 				newbook.bookfile = "ruined.json"
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes "database player book delete" admin verb so its properly added to the admin tab
Fixes player book texts (texts are now properly defined)
Adds a very small chance for a book crafting kit to spawn in the archives (as a pleasant little reward)
Fixes player book spawn, and adjusts the spawn rate rate to be proportional (to a max and min of 90 and 10%) to the amount of player books
Adjusts the probability of a book to have ruined text (1/3rd)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
