### PR TITLE
Inconsistency between Weapon and Armor smithing steel numbers

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -44,19 +44,19 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail
 
 /datum/anvil_recipe/armor/hauberk
-	name = "hauberk (+2 steel)"
+	name = "hauberk (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 
 /datum/anvil_recipe/armor/plate
-	name = "half-plate armor (+3 steel)"
+	name = "half-plate armor (+2 steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel,/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate
 
 /datum/anvil_recipe/armor/platefull
-	name = "full-plate armor (+4 steel)"
+	name = "full-plate armor (+3 steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full
@@ -82,7 +82,7 @@
 	created_item = /obj/item/clothing/under/roguetown/chainlegs
 
 /datum/anvil_recipe/armor/hplate
-	name = "cuirass (+2 steel)"
+	name = "cuirass (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half
@@ -113,25 +113,25 @@
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet
 
 /datum/anvil_recipe/armor/helmetsallv
-	name = "visored sallet (+2 steel)"
+	name = "visored sallet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet/visored
 
 /datum/anvil_recipe/armor/helmetbuc
-	name = "bucket helmet (+2 steel)"
+	name = "bucket helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
 
 /datum/anvil_recipe/armor/helmetpig
-	name = "pigface helmet (+2 steel)"
+	name = "pigface helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/pigface
 
 /datum/anvil_recipe/armor/helmetknight
-	name = "knight's helmet (+2 steel)"
+	name = "knight's helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight
@@ -147,25 +147,25 @@
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel
 
 /datum/anvil_recipe/armor/astratahelm
-	name = "astrata helmet (+2 steel)"
+	name = "astrata helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm
 
 /datum/anvil_recipe/armor/necrahelm
-	name = "necra helmet (+2 steel)"
+	name = "necra helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/necrahelm
 
 /datum/anvil_recipe/armor/nochelm
-	name = "noc helmet (+2 steel)"
+	name = "noc helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/nochelm
 
 /datum/anvil_recipe/armor/dendorhelm
-	name = "dendor helmet (+2 steel)"
+	name = "dendor helmet (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/dendorhelm

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -89,7 +89,7 @@
 	created_item = /obj/item/rogueweapon/huntingknife/cleaver/combat
 
 /datum/anvil_recipe/weapons/smace
-	name = "steel mace (+2 steel)"
+	name = "steel mace (+steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/mace/steel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is a basic change to the numbers fixing what weapons had mostly right but armor was wrong, as a blacksmith you are already using a steel to see that item, so it makes sense to show only +steel if you are using only one extra or +2 steel if you are using two extra.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

I experencied myself as blacksmith that the difference between numbers was quite confusing, even more for a first timer, sometimes overcharging clients because i thought you would need to use more steel than the number truly was.
