### PR TITLE
Knight Gatemaster keyGODS, Bailiff Counciller keyNERDS

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -2,7 +2,7 @@
 
 /obj/item/keyring
 	name = "keyring"
-	desc = "Will help you organize your keys."
+	desc = ""
 	icon_state = "keyring0"
 	icon = 'icons/roguetown/items/keys.dmi'
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
@@ -50,7 +50,7 @@
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/keyring/proc/addtoring(obj/item/I)
+/obj/item/keyring/proc/addtoring(var/obj/item/I)
 	if(!I || !istype(I))
 		return 0
 	I.loc = src
@@ -126,27 +126,17 @@
 /obj/item/keyring/sheriff
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
-/obj/item/keyring/bailiff
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
-
-
-/obj/item/keyring/councillor
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
-
 /obj/item/keyring/guard
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
 
 /obj/item/keyring/guardcastle
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
 
-/obj/item/keyring/velder
-	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/blacksmith/town, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)
-
-/obj/item/keyring/vtavern
-	keys = list(/obj/item/roguekey/tavern/village, /obj/item/roguekey/roomvi/village, /obj/item/roguekey/roomv/village, /obj/item/roguekey/roomiv/village, /obj/item/roguekey/roomiii/village, /obj/item/roguekey/roomii/village, /obj/item/roguekey/roomi/village)
-
 /obj/item/keyring/gatemaster
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor)
+
+/obj/item/keyring/knight
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/knight)
 
 /obj/item/keyring/merchant
 	keys = list(/obj/item/roguekey/shop, /obj/item/roguekey/merchant)
@@ -178,14 +168,9 @@
 /obj/item/keyring/steward
 	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
-/obj/item/keyring/clerk
-	keys = list(/obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
-
 /obj/item/keyring/dungeoneer
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison)
 
 /obj/item/keyring/servant
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison)
 
-/obj/item/keyring/archivist
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/archive)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -140,10 +140,10 @@
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
 
 /obj/item/keyring/guardcastle
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor)
 
 /obj/item/keyring/knight	
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/manor)
 
 /obj/item/keyring/velder
 	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/blacksmith/town, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)
@@ -158,7 +158,7 @@
 	keys = list(/obj/item/roguekey/shop, /obj/item/roguekey/merchant)
 
 /obj/item/keyring/mguard
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor)
 
 /obj/item/keyring/mage
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/tower, /obj/item/roguekey/mage)
@@ -182,10 +182,10 @@
 	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard) //i think if one person was to have more then 5 keys, it would be dis dude
 
 /obj/item/keyring/steward
-	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/keyring/clerk
-	keys = list(/obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list( /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/keyring/dungeoneer
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -128,7 +128,7 @@
 		desc = ""
 
 /obj/item/keyring/sheriff
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor)
 
 /obj/item/keyring/bailiff
 	keys = list(/obj/item/roguekey/bailiff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison) 
@@ -143,7 +143,7 @@
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor)
 
 /obj/item/keyring/knight	
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor)
 
 /obj/item/keyring/velder
 	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/blacksmith/town, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -1,8 +1,12 @@
 /////////////////// KEYRING ////////////////////
 
+
+
+//READ BEFORE YOU ADD FUCKING KEYS, a keyring can only have 5 keys on at a time, spritewise, codewise, it means if they remove a key from a keyring which has more then 5, they will be unable to add the key back.
+
 /obj/item/keyring
 	name = "keyring"
-	desc = ""
+	desc = "Will help you organize your keys."
 	icon_state = "keyring0"
 	icon = 'icons/roguetown/items/keys.dmi'
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
@@ -50,7 +54,7 @@
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/keyring/proc/addtoring(var/obj/item/I)
+/obj/item/keyring/proc/addtoring(obj/item/I)
 	if(!I || !istype(I))
 		return 0
 	I.loc = src
@@ -124,7 +128,13 @@
 		desc = ""
 
 /obj/item/keyring/sheriff
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
+
+/obj/item/keyring/bailiff
+	keys = list(/obj/item/roguekey/bailiff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison) 
+
+/obj/item/keyring/councillor
+	keys = list(/obj/item/roguekey/bailiff)
 
 /obj/item/keyring/guard
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
@@ -132,11 +142,17 @@
 /obj/item/keyring/guardcastle
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
 
-/obj/item/keyring/gatemaster
-	keys = list(/obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor)
+/obj/item/keyring/knight	
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/manor)
 
-/obj/item/keyring/knight
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/knight)
+/obj/item/keyring/velder
+	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/blacksmith/town, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)
+
+/obj/item/keyring/vtavern
+	keys = list(/obj/item/roguekey/tavern/village, /obj/item/roguekey/roomvi/village, /obj/item/roguekey/roomv/village, /obj/item/roguekey/roomiv/village, /obj/item/roguekey/roomiii/village, /obj/item/roguekey/roomii/village, /obj/item/roguekey/roomi/village)
+
+/obj/item/keyring/gatemaster
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
 
 /obj/item/keyring/merchant
 	keys = list(/obj/item/roguekey/shop, /obj/item/roguekey/merchant)
@@ -163,10 +179,13 @@
 	keys = list(/obj/item/roguekey/nightman, /obj/item/roguekey/nightmaiden)
 
 /obj/item/keyring/hand
-	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard) //i think if one person was to have more then 5 keys, it would be dis dude
 
 /obj/item/keyring/steward
 	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+
+/obj/item/keyring/clerk
+	keys = list(/obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/keyring/dungeoneer
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison)
@@ -174,3 +193,5 @@
 /obj/item/keyring/servant
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison)
 
+/obj/item/keyring/archivist
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/archive)

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -57,6 +57,12 @@
 	icon_state = "spikekey"
 	lockid = "garrison"
 
+/obj/item/roguekey/knight
+	name = "knight"
+	desc = "This key belongs to one of the royal knights."
+	icon_state = "greenkey"
+	lockid = "knight"
+
 /obj/item/roguekey/dungeon
 	name = "dungeon key"
 	desc = "This key should unlock the rusty bars and doors of the dungeon."
@@ -71,14 +77,15 @@
 
 /obj/item/roguekey/sheriff
 	name = "sheriff's key"
+	desc = "This key opens the sheriff quarters.
 	icon_state = "cheesekey"
 	lockid = "sheriff"
 
 /obj/item/roguekey/bailiff
 	name = "bailiff's key"
-	desc = "This key belongs to the town sheriff."
+	desc = "This key belongs to the town bailiff."
 	icon_state = "cheesekey"
-	lockid = "sheriff"
+	lockid = "bailiff"
 
 /obj/item/roguekey/merchant
 	name = "merchant's key"

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -57,12 +57,6 @@
 	icon_state = "spikekey"
 	lockid = "garrison"
 
-/obj/item/roguekey/knight
-	name = "knight"
-	desc = "This key belongs to one of the royal knights."
-	icon_state = "greenkey"
-	lockid = "knight"
-
 /obj/item/roguekey/dungeon
 	name = "dungeon key"
 	desc = "This key should unlock the rusty bars and doors of the dungeon."
@@ -75,9 +69,15 @@
 	icon_state = "cheesekey"
 	lockid = "vault"
 
+/obj/item/roguekey/knight
+	name = "knight"
+	desc = "This key belongs to one of the royal knights"
+	icon_state = "greenkey"
+	lockid = "knight"
+
 /obj/item/roguekey/sheriff
 	name = "sheriff's key"
-	desc = "This key opens the sheriff quarters.
+	desc = "This key leads to the sheriff quarters."
 	icon_state = "cheesekey"
 	lockid = "sheriff"
 

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -34,7 +34,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/merc
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/full
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-	beltl = /obj/item/keyring/guardcastle
+	beltl = /obj/item/keyring/knight
 	belt = /obj/item/storage/belt/rogue/leather/hand
 	backr = /obj/item/storage/backpack/rogue/satchel
 	if(H.mind)


### PR DESCRIPTION
adds knight keyring, (they're never getting personal rooms)

also renames the "bailiff" to the real bailiff key.

removes wall key from most keyrings, key is never used and it should be reserved for the gatekeeper

also removes keys from bailiff and councillers because why would booknerds that aren't the steward and the archivist get access to the garrison, the manor AND the dungeon.

bailiff and councillers also don't live in the graveyard.