### PR TITLE
Re-add elf queens, remove dark-elves allowed in everything, and removes female squires

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -12,8 +12,6 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Tiefling",
-		"Dark Elf",
 	)
 	tutorial = "You are the most experienced idiot to volunteer to the Bog Guard... What a mistake that was. You report to the Sheriff, and your job is to keep the bogmen in line and to ensure the routes to the keep are safe. May the ten have mercy on you..."
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -7,7 +7,9 @@
 	spawn_positions = 1
 
 	allowed_sexes = list(FEMALE)
-	allowed_races = list("Humen")
+	allowed_races = list("Humen",
+	"Elf",
+	"Half-Elf")
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the King's most trusted confidant and likely friend throughout your marriage. Your loyalty and, perhaps, love; will be tested this day. For the daggers that threaten your beloved are as equally pointed at your own throat.."
 
 	outfit = /datum/outfit/job/roguetown/lady

--- a/code/modules/jobs/job_types/roguetown/peasants/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butler.dm
@@ -13,8 +13,6 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Tiefling",
-		"Dark Elf",
 	)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 

--- a/code/modules/jobs/job_types/roguetown/peasants/prisoner.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/prisoner.dm
@@ -13,8 +13,6 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Tiefling",
-		"Dark Elf",
 	)
 	tutorial = "How does it feel to be the rat in the cage? You're unwanted, unloved and entirely worthless in society. You're kept around for the amusement of the Guards and for the oft chance someone comes to pay your ransom. Might as well start praying to whatever god you find solace in."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -12,8 +12,6 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Tiefling",
-		"Dark Elf",
 	)
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_YOUNG)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -6,7 +6,7 @@
 	total_positions = 0
 	spawn_positions = 2
 	f_title = "Princess"
-	allowed_races = list("Humen", "Half-Elf") //lord and lady cant be an elf, but prince could be a bastard child which is funny
+	allowed_races = list("Humen", "Half-Elf")
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_YOUNG)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -12,8 +12,6 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Tiefling",
-		"Dark Elf"
 	)
 	allowed_ages = list(AGE_YOUNG)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -12,7 +12,7 @@
 		"Dwarf",
 		"Aasimar",
 	) //same shit as town guard
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	allowed_ages = list(AGE_YOUNG)
 
 	tutorial = "Mom 'n' Da said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. "


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Elf queens are very based and the description for queen says they were married for political reasons. 

Reverted #590 adding dark elfs and tieflings to everything, the whole point is that they're shunned in society, you literally get negative moodlet for looking at them. So they wouldn't be allowed as butler. And prisoner doesn't make sense for them either since they would just be executed and wouldn't be kept as a political prisoner. They definitely wouldn't be allowed to be the bogmaster.  I left them for blacksmith which is kind of borderline since blacksmith is a respected position but it's still a peasant position.

Removes female squires since the whole point of squires is that they are training to be a knight, which can only be male. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

How can you not like elf queens they're just very based.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
