### PR TITLE
Wooden staff back to 10 wdefense

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -46,7 +46,7 @@
 	pixel_x = -16
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	wdefense = 2
+	wdefense = 10
 	bigboy = TRUE
 	gripsprite = TRUE
 	associated_skill = /datum/skill/combat/polearms


### PR DESCRIPTION
The initial value for them in the repo was 2, this got changed to 10, and then it ended up back at 2.
This attempts to move it back to 10.
The niche of a wooden staff is primarily a defensive weapon.
