### PR TITLE
Rotten Berries (in your piehole)

### DIFF
--- a/code/modules/hydroponics/grown/roguetown.dm
+++ b/code/modules/hydroponics/grown/roguetown.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(berrycolors)
 	var/color_index = "good"
 	can_distill = TRUE
 	distill_reagent = /datum/reagent/consumable/ethanol/beer/wine
-	rotprocess = 10 MINUTES
+	rotprocess = 15 MINUTES
 
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue/Initialize()
 	if(GLOB.berrycolors[color_index])


### PR DESCRIPTION
## About The Pull Request

* Increases Jacksberry rot time to 15 from 10 minutes

## Why It's Good For The Game

Rotting faster than raw meat makes no sense so at least have an equal timer.
Also makes life a tiny bit easier for winemaking butlers and hobos trying to forage.
