### PR TITLE
Fix warrior monster hunter variant

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -102,7 +102,7 @@
 				H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 				H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 				H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
-				backr = /obj/item/rogueweapon/spear/billhook
+				r_hand = /obj/item/rogueweapon/spear/billhook
 			else
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale // No helms for monster hunters.
 				H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Rolled the polearm variant, did not spawn with billhook likely due to polearms no longer able to fit in back slots. Should spawn in the right hand fine similar to the grenzelhoft mercs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
