### PR TITLE
Adds more Stockpiles to make the system actually worth it.

### DIFF
--- a/_maps/map_files/roguetown2/roguetown2.dmm
+++ b/_maps/map_files/roguetown2/roguetown2.dmm
@@ -35,15 +35,11 @@
 	locked = 1;
 	lockid = "manor"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "an" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "ao" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -67,9 +63,7 @@
 "ar" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "as" = (
 /turf/open/floor/rogue/cobble,
@@ -99,7 +93,6 @@
 /area/rogue/under/cave)
 "ay" = (
 /obj/structure/mineral_door/bars{
-	locked = 0;
 	lockid = "lord"
 	},
 /turf/open/floor/rogue/cobble,
@@ -116,20 +109,16 @@
 /area/rogue/indoors/town/vault)
 "aB" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "aC" = (
 /obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "aD" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -165,16 +154,13 @@
 /area/rogue/under/town/basement)
 "aL" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "aM" = (
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "aN" = (
 /obj/structure/bars,
@@ -345,7 +331,6 @@
 /area/rogue/under/town/basement)
 "bs" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -358,7 +343,6 @@
 /area/rogue/under/town/basement)
 "bu" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -388,7 +372,6 @@
 /area/rogue/under/town/basement)
 "by" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -449,7 +432,6 @@
 "bJ" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
 	lockid = "dungeon"
 	},
 /turf/open/floor/rogue/blocks,
@@ -457,7 +439,6 @@
 "bK" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
 	locked = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -575,7 +556,6 @@
 /area/rogue/under/town/sewer)
 "cj" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -639,7 +619,6 @@
 "cw" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "dungeon"
 	},
@@ -682,7 +661,6 @@
 /area/rogue/under/town/basement)
 "cE" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -748,7 +726,6 @@
 "cS" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
 	lockid = "dungeon"
 	},
 /turf/open/floor/rogue/cobble,
@@ -783,7 +760,6 @@
 /area/rogue/under/town/basement)
 "cY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -816,7 +792,6 @@
 "dd" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "dungeon"
 	},
@@ -841,7 +816,6 @@
 "dh" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "dungeon"
 	},
@@ -911,8 +885,7 @@
 /area/rogue/under/town/basement)
 "dt" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -927,21 +900,18 @@
 /area/rogue/under/town/basement)
 "dw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement)
 "dx" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "dy" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -974,7 +944,6 @@
 /area/rogue/under/town/basement)
 "dE" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -1022,7 +991,6 @@
 /area/rogue/under/town/basement)
 "dM" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -1049,9 +1017,7 @@
 /area/rogue/under/town/basement)
 "dS" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	icon_state = "wooddir";
-	locked = 0
+	dir = 1
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement)
@@ -1064,7 +1030,6 @@
 /area/rogue/under/town/basement)
 "dU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -1089,7 +1054,6 @@
 /area/rogue/under/town/basement)
 "dY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -1120,8 +1084,6 @@
 "ed" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
-	locked = 0;
 	lockid = "garrison"
 	},
 /turf/open/floor/rogue/cobble,
@@ -1143,14 +1105,12 @@
 /area/rogue/under/town/basement)
 "eh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "ei" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -1188,7 +1148,6 @@
 /area/rogue/under/cave)
 "ep" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
@@ -1241,7 +1200,6 @@
 /area/rogue/indoors/town/manor)
 "eD" = (
 /obj/structure/chair/bench{
-	icon_state = "bench";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -1283,7 +1241,6 @@
 /area/rogue/indoors/town/manor)
 "eQ" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/grass,
@@ -1300,9 +1257,7 @@
 /area/rogue/indoors/town/manor)
 "eU" = (
 /obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "eV" = (
 /obj/structure/fluff/walldeco/rpainting/crown{
@@ -1341,7 +1296,6 @@
 /area/rogue/indoors/town)
 "fg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -1352,8 +1306,7 @@
 /area/rogue/indoors/town/bath)
 "fi" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -1393,7 +1346,6 @@
 /area/rogue/indoors/town/manor)
 "fr" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -1433,7 +1385,6 @@
 /area/rogue/indoors/town/manor)
 "fz" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -1443,7 +1394,6 @@
 /area/rogue/indoors/town/tavern)
 "fB" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -1457,9 +1407,7 @@
 	lockid = "manor";
 	name = "Service Halls"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "fD" = (
 /obj/structure/roguemachine/camera,
@@ -1494,7 +1442,6 @@
 /area/rogue/indoors/town/church/chapel)
 "fK" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -1505,12 +1452,9 @@
 /area/rogue/outdoors/rtfield)
 "fN" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "fO" = (
 /turf/open/water/sewer,
@@ -1578,23 +1522,19 @@
 /area/rogue/outdoors/rtfield)
 "ge" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "gf" = (
 /obj/structure/fluff/clock,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "gg" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "gh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -1654,14 +1594,12 @@
 /area/rogue/indoors/town/bath)
 "gr" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "gs" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet,
@@ -1680,7 +1618,6 @@
 /area/rogue/outdoors/rtfield)
 "gw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -1695,28 +1632,24 @@
 /area/rogue/indoors/town)
 "gB" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "gC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "gD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "gE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/closed/wall/mineral/rogue/stone,
@@ -1734,7 +1667,6 @@
 /area/rogue/indoors/town/bath)
 "gH" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks{
@@ -1764,7 +1696,6 @@
 	redstone_id = "warehouse_shutter"
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -1777,13 +1708,10 @@
 /obj/effect/landmark/start/manorguardsman{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 2
-	},
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "gR" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -1801,19 +1729,16 @@
 /area/rogue/under/town/basement)
 "gV" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "gX" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -1827,9 +1752,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
 "hc" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "hd" = (
 /turf/open/transparent/openspace,
@@ -1886,7 +1809,6 @@
 "ht" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -1926,7 +1848,6 @@
 /area/rogue/outdoors/town)
 "hC" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -1962,7 +1883,6 @@
 "hJ" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "nightmaiden"
 	},
@@ -1970,16 +1890,13 @@
 /area/rogue/indoors/town/bath)
 "hL" = (
 /obj/structure/stairs/fancy/c{
-	icon_state = "fancy_stairs_c";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord,
 /area/rogue/indoors/town/manor)
 "hM" = (
 /obj/structure/toilet,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "hN" = (
 /obj/structure/table/wood,
@@ -1992,7 +1909,6 @@
 "hO" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	icon_state = "donjondir";
 	lockid = "steward";
 	locked = 1
 	},
@@ -2031,18 +1947,13 @@
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/reagent_containers/powder/flour/salt,
 /obj/item/reagent_containers/powder/flour/salt,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "hY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "hZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -2074,7 +1985,6 @@
 /area/rogue/outdoors/rtfield)
 "if" = (
 /obj/effect/landmark/start/butler{
-	icon_state = "arrow";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile{
@@ -2156,7 +2066,6 @@
 /area/rogue/indoors/town)
 "iB" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -2166,7 +2075,6 @@
 /area/rogue/outdoors/rtfield)
 "iF" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/closed,
@@ -2192,7 +2100,6 @@
 "iK" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "garrison";
 	max_integrity = 9999
@@ -2220,7 +2127,6 @@
 /area/rogue/indoors/town/manor)
 "iO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2250,7 +2156,6 @@
 /area/rogue/outdoors/rtfield)
 "iY" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2298,7 +2203,6 @@
 /area/rogue/indoors/town)
 "jj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -2310,9 +2214,7 @@
 /area/rogue/indoors/town/magician)
 "jl" = (
 /obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "jm" = (
 /obj/structure/mineral_door/wood{
@@ -2329,7 +2231,6 @@
 /area/rogue/indoors/town/magician)
 "jo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2344,9 +2245,7 @@
 /area/rogue/indoors/town/shop)
 "jq" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "jr" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
@@ -2370,9 +2269,7 @@
 "jv" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "jx" = (
 /turf/open/floor/rogue/wood,
@@ -2393,14 +2290,12 @@
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "jF" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks{
@@ -2422,7 +2317,6 @@
 /area/rogue/indoors/town/manor)
 "jH" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
@@ -2461,18 +2355,10 @@
 /area/rogue/outdoors/town)
 "jP" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"jQ" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town)
 "jR" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/blocks/stonered,
@@ -2515,14 +2401,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/shop)
 "kf" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "kg" = (
 /obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
@@ -2569,7 +2452,6 @@
 /area/rogue/indoors/town)
 "kp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
@@ -2590,7 +2472,6 @@
 /area/rogue/indoors/town/manor)
 "ku" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4;
 	locked = 1
 	},
@@ -2647,7 +2528,6 @@
 /area/rogue/indoors/town/manor)
 "kG" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -2700,7 +2580,6 @@
 /area/rogue/indoors/town/church)
 "kT" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -2710,7 +2589,6 @@
 /area/rogue/indoors/town/church)
 "kV" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -2760,7 +2638,6 @@
 /area/rogue/outdoors/town)
 "lf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2827,7 +2704,6 @@
 /area/rogue/indoors/town)
 "lx" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2901,7 +2777,6 @@
 /area/rogue/indoors/town/dwarfin)
 "lQ" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2926,7 +2801,6 @@
 /area/rogue/indoors/town/garrison)
 "lW" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -2941,33 +2815,28 @@
 /area/rogue/indoors/town/garrison)
 "lY" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "lZ" = (
 /obj/structure/roguethrone{
-	pixel_x = -32;
 	name = "Throne of Rockhill"
 	},
 /obj/effect/landmark/start/lord,
 /obj/structure/roguemachine/titan{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
 "ma" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "mb" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/church,
@@ -3021,7 +2890,6 @@
 /area/rogue/indoors/town/manor)
 "mp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -3050,9 +2918,7 @@
 /obj/effect/landmark/start/manorguardsman{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile/masonic{
-	dir = 2
-	},
+/turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "mx" = (
 /obj/structure/mineral_door/wood{
@@ -3086,7 +2952,6 @@
 "mE" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "steward"
 	},
@@ -3113,7 +2978,6 @@
 /area/rogue/indoors/town/shop)
 "mJ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/effect/landmark/start/nightmaiden{
@@ -3158,14 +3022,12 @@
 /area/rogue/indoors/town)
 "mV" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "mW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/mason,
@@ -3204,9 +3066,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "nf" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "ng" = (
 /obj/machinery/light/rogue/firebowl,
@@ -3233,7 +3093,6 @@
 "nl" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "nightmaiden"
 	},
@@ -3282,7 +3141,6 @@
 /area/rogue/outdoors/town)
 "nu" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -3292,7 +3150,6 @@
 /area/rogue/indoors/town/garrison)
 "nz" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -3301,7 +3158,6 @@
 /area/rogue/indoors/town/manor)
 "nA" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
@@ -3318,7 +3174,6 @@
 /area/rogue/indoors/town)
 "nE" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -3351,9 +3206,7 @@
 	},
 /area/rogue/indoors)
 "nO" = (
-/obj/structure/fluff/wallclock{
-	pixel_y = 32
-	},
+/obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
 "nP" = (
@@ -3395,13 +3248,6 @@
 "nY" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"nZ" = (
-/obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
 "ob" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -3415,14 +3261,12 @@
 /area/rogue/indoors/town/manor)
 "oc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/bath)
 "od" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3469,7 +3313,6 @@
 	pixel_y = -1
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -3499,9 +3342,7 @@
 /area/rogue/outdoors/town)
 "op" = (
 /obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "oq" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -3521,7 +3362,6 @@
 /area/rogue/outdoors/town)
 "ou" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -3533,7 +3373,6 @@
 /area/rogue/indoors/town/garrison)
 "ow" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3546,7 +3385,6 @@
 /area/rogue/indoors/town/shop)
 "oz" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -3575,7 +3413,6 @@
 "oE" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/guardsman{
-	icon_state = "arrow";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -3608,7 +3445,6 @@
 /area/rogue/indoors/town)
 "oM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/blocks,
@@ -3633,21 +3469,18 @@
 /area/rogue/outdoors/rtfield)
 "oT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
 "oU" = (
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "oV" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -3673,7 +3506,6 @@
 /area/rogue/outdoors/town)
 "pc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -3734,7 +3566,6 @@
 "po" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -3745,7 +3576,6 @@
 /area/rogue/outdoors/town)
 "pq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -3772,7 +3602,6 @@
 /area/rogue/outdoors/town)
 "pv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3796,7 +3625,6 @@
 /area/rogue/indoors/town/garrison)
 "pz" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -3833,7 +3661,6 @@
 /area/rogue/outdoors/rtfield)
 "pH" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4;
 	locked = 1
 	},
@@ -3863,7 +3690,6 @@
 "pM" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3878,7 +3704,6 @@
 /area/rogue/indoors/town/manor)
 "pO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
@@ -3903,7 +3728,6 @@
 /area/rogue/indoors/town/shop)
 "pU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks{
@@ -3926,7 +3750,6 @@
 /area/rogue/indoors/town/manor)
 "pZ" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -3961,16 +3784,12 @@
 /area/rogue/indoors/town/manor)
 "qg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/vagrant{
-	icon_state = "arrow";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "qh" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -3979,7 +3798,6 @@
 "qi" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -3998,7 +3816,6 @@
 /area/rogue/indoors/town/manor)
 "qp" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -4045,7 +3862,6 @@
 /area/rogue/outdoors/town)
 "qB" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4080,9 +3896,7 @@
 /area/rogue/indoors/town)
 "qI" = (
 /obj/structure/fluff/statue/gargoyle/moss,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "qK" = (
 /obj/structure/table/wood{
@@ -4100,7 +3914,6 @@
 /area/rogue/indoors/town/manor)
 "qM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
@@ -4112,7 +3925,6 @@
 /area/rogue/indoors/town)
 "qP" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks{
@@ -4121,7 +3933,6 @@
 /area/rogue/indoors)
 "qQ" = (
 /obj/structure/fluff/walldeco/steward{
-	icon_state = "steward";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -4138,19 +3949,15 @@
 /area/rogue/under/town/basement)
 "qV" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
 "qW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "qY" = (
 /turf/open/floor/rogue/concrete,
@@ -4188,7 +3995,6 @@
 /area/rogue/outdoors/town)
 "re" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4199,14 +4005,12 @@
 /area/rogue/indoors/town/magician)
 "rg" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "ri" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
@@ -4307,7 +4111,6 @@
 /area/rogue/outdoors/rtfield)
 "rF" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 8
 	},
 /area/rogue/indoors/town/manor)
@@ -4372,7 +4175,6 @@
 /area/rogue/outdoors/town)
 "rY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/structure/roguemachine/scomm,
@@ -4392,7 +4194,6 @@
 /area/rogue/indoors/town/shop)
 "sb" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -4400,7 +4201,6 @@
 /area/rogue/outdoors/town)
 "sc" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks{
@@ -4471,7 +4271,6 @@
 /area/rogue/indoors/town)
 "so" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -4487,7 +4286,6 @@
 /area/rogue/indoors/town/dwarfin)
 "ss" = (
 /obj/effect/landmark/start/hand{
-	icon_state = "arrow";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile{
@@ -4496,7 +4294,6 @@
 /area/rogue/indoors/town/manor)
 "st" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4504,7 +4301,6 @@
 "sv" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/butler{
-	icon_state = "arrow";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4522,14 +4318,11 @@
 "sy" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "sz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 2
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/woodturned,
@@ -4579,7 +4372,6 @@
 /area/rogue/outdoors/rtfield)
 "sL" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/outdoors/rtfield)
@@ -4592,7 +4384,6 @@
 /area/rogue/indoors/town/manor)
 "sO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/blocks,
@@ -4611,7 +4402,6 @@
 /area/rogue/indoors/town/manor)
 "sS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/stone,
@@ -4626,9 +4416,7 @@
 /area/rogue/indoors/town)
 "sU" = (
 /obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "sV" = (
 /turf/open/floor/carpet/stellar,
@@ -4636,21 +4424,18 @@
 "sX" = (
 /obj/structure/floordoor/gatehatch/inner,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "tb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "tc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/stone,
@@ -4678,7 +4463,6 @@
 /area/rogue/indoors/town/church)
 "tg" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/effect/landmark/start/nightmaiden{
@@ -4688,7 +4472,6 @@
 /area/rogue/indoors/town/bath)
 "th" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -4713,7 +4496,6 @@
 /area/rogue/indoors/town/manor)
 "tn" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing,
@@ -4721,7 +4503,6 @@
 /area/rogue/outdoors/rtfield)
 "to" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -4767,13 +4548,16 @@
 /area/rogue/indoors/town/dwarfin)
 "tA" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/dwarfin)
+"tB" = (
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "tC" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /obj/machinery/light/rogue/torchholder,
@@ -4794,7 +4578,6 @@
 /area/rogue/indoors/town)
 "tJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -4803,13 +4586,10 @@
 /area/rogue/indoors/town/shop)
 "tK" = (
 /obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "tL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -4826,7 +4606,6 @@
 /area/rogue/indoors/town/manor)
 "tQ" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -4858,9 +4637,7 @@
 /area/rogue/outdoors/rtfield)
 "tW" = (
 /obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "tX" = (
 /obj/item/reagent_containers/glass/cup/silver,
@@ -5049,14 +4826,12 @@
 /area/rogue/indoors/town/dwarfin)
 "uL" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "uM" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 8;
 	lockid = "townroom2"
 	},
@@ -5072,9 +4847,7 @@
 "uO" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/vagrant,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "uP" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -5129,9 +4902,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "uZ" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "va" = (
 /turf/open/floor/rogue/herringbone,
@@ -5148,7 +4919,6 @@
 /area/rogue/outdoors/rtfield)
 "vd" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -5172,7 +4942,6 @@
 "vi" = (
 /obj/structure/roguewindow,
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -5253,13 +5022,10 @@
 /area/rogue/indoors/town)
 "vy" = (
 /obj/structure/roguemachine/money/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "vz" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -5274,7 +5040,6 @@
 /area/rogue/indoors/town/manor)
 "vC" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -5285,7 +5050,6 @@
 /area/rogue/under/town/basement)
 "vE" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -5315,13 +5079,10 @@
 /obj/item/cooking/pan,
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/powder/flour,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "vL" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -5393,9 +5154,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "we" = (
 /obj/structure/mineral_door/wood{
@@ -5440,9 +5199,7 @@
 	icon_state = "longtable";
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "wo" = (
 /obj/structure/table/wood{
@@ -5457,14 +5214,12 @@
 /area/rogue/outdoors/rtfield)
 "wt" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/dwarfin)
 "wu" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
@@ -5489,7 +5244,6 @@
 /area/rogue/outdoors/town)
 "wB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -5645,7 +5399,6 @@
 /area/rogue/outdoors/town)
 "xj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -5741,7 +5494,6 @@
 /area/rogue/indoors/town/manor)
 "xM" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -5756,7 +5508,6 @@
 "xP" = (
 /obj/machinery/light/rogue/chand,
 /obj/effect/landmark/start/jester{
-	icon_state = "arrow";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -5786,7 +5537,6 @@
 /area/rogue/indoors/town/bath)
 "xU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -5810,7 +5560,6 @@
 /area/rogue/outdoors/town/roofs)
 "xZ" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/tile{
@@ -5867,7 +5616,6 @@
 /area/rogue/indoors/town/manor)
 "yk" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
@@ -5915,7 +5663,6 @@
 /area/rogue/indoors/town/manor)
 "yu" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -5925,7 +5672,6 @@
 /area/rogue/outdoors/town/roofs)
 "yx" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -5955,13 +5701,10 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "yD" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -5981,7 +5724,6 @@
 /area/rogue/indoors/town/church)
 "yH" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -6083,11 +5825,9 @@
 /area/rogue/outdoors/beach)
 "zb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -6185,7 +5925,6 @@
 /area/rogue/indoors/town/magician)
 "zt" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile{
@@ -6267,7 +6006,6 @@
 /area/rogue/indoors/town/church)
 "zG" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
@@ -6379,7 +6117,6 @@
 /area/rogue/indoors/town/manor)
 "Ac" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6396,7 +6133,6 @@
 /area/rogue/outdoors/town)
 "Ae" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/landmark/start/monk,
@@ -6410,7 +6146,6 @@
 /area/rogue/indoors/town/church/chapel)
 "Ag" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /obj/effect/landmark/start/churchling,
@@ -6452,7 +6187,6 @@
 /area/rogue/indoors/town/garrison)
 "An" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood,
@@ -6466,7 +6200,6 @@
 /area/rogue/indoors/town/church/chapel)
 "Ap" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /turf/open/floor/rogue/church,
@@ -6476,21 +6209,18 @@
 /area/rogue/indoors/town/church/chapel)
 "Ar" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "As" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "At" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/c,
@@ -6528,7 +6258,6 @@
 /area/rogue/indoors/town/church)
 "AA" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
@@ -6544,15 +6273,12 @@
 /area/rogue/indoors/town/church/chapel)
 "AD" = (
 /obj/structure/table/church{
-	icon_state = "churchtable";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "AE" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/outdoors/town/roofs)
 "AF" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -6605,7 +6331,6 @@
 /area/rogue/indoors/town/church/chapel)
 "AO" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -6613,7 +6338,6 @@
 "AP" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -6626,7 +6350,6 @@
 "AR" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -6745,14 +6468,12 @@
 /area/rogue/indoors/town/church/chapel)
 "Bq" = (
 /obj/structure/chair/bench/church{
-	icon_state = "church_benchleft";
 	dir = 1
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "Br" = (
 /obj/structure/chair/bench/church/mid{
-	icon_state = "church_benchmid";
 	dir = 1
 	},
 /turf/open/floor/rogue/church,
@@ -6791,20 +6512,14 @@
 	dir = 1
 	},
 /obj/item/candle/yellow,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Bx" = (
 /obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "By" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Bz" = (
 /obj/structure/rack/rogue/shelf/big,
@@ -6868,7 +6583,6 @@
 /area/rogue/indoors/town/garrison)
 "BK" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -6879,14 +6593,12 @@
 /area/rogue/indoors/town/church/chapel)
 "BM" = (
 /obj/structure/chair/bench/church{
-	icon_state = "church_benchleft";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "BN" = (
 /obj/structure/chair/bench/church/mid{
-	icon_state = "church_benchmid";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -6910,9 +6622,7 @@
 /area/rogue/indoors/town/tavern)
 "BR" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "BS" = (
 /turf/open/floor/rogue/wood,
@@ -6924,7 +6634,6 @@
 /area/rogue/indoors/town/tavern)
 "BU" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6933,7 +6642,6 @@
 /area/rogue/indoors/town/tavern)
 "BV" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -6954,7 +6662,6 @@
 /area/rogue/indoors/town/tavern)
 "BY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -6968,8 +6675,7 @@
 /area/rogue/indoors/town/garrison)
 "Cb" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	icon_state = "wooddir"
+	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
@@ -6985,7 +6691,6 @@
 /area/rogue/indoors/town/garrison)
 "Cd" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/decowood,
@@ -7007,24 +6712,17 @@
 	dir = 5
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Cg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Ch" = (
 /obj/structure/roguemachine/money/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Ci" = (
 /obj/structure/closet/crate/chest,
@@ -7093,9 +6791,7 @@
 	icon_state = "largetable";
 	dir = 9
 	},
-/obj/structure/fluff/walldeco/wantedposter{
-	pixel_y = 32
-	},
+/obj/structure/fluff/walldeco/wantedposter,
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
@@ -7110,7 +6806,6 @@
 /area/rogue/indoors/town/garrison)
 "Cu" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -7130,7 +6825,6 @@
 /area/rogue/indoors/town/garrison)
 "Cx" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/tile{
@@ -7173,9 +6867,7 @@
 	dir = 6
 	},
 /obj/item/storage/roguebag,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "CE" = (
 /obj/structure/table/wood{
@@ -7198,14 +6890,12 @@
 /area/rogue/indoors/town/tavern)
 "CG" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "CH" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -7219,7 +6909,6 @@
 /area/rogue/indoors/town)
 "CJ" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -7243,15 +6932,6 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/garrison)
-"CN" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
 /area/rogue/indoors/town/garrison)
 "CO" = (
 /turf/open/floor/carpet/royalblack,
@@ -7303,15 +6983,11 @@
 	dir = 1
 	},
 /obj/item/cooking/pan,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "CZ" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "Da" = (
 /obj/structure/mineral_door/wood/window{
@@ -7322,7 +6998,6 @@
 /area/rogue/indoors/town/tavern)
 "Db" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -7345,7 +7020,6 @@
 /area/rogue/indoors/town)
 "Df" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -7376,7 +7050,6 @@
 /area/rogue/indoors/town/garrison)
 "Dk" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7385,7 +7058,6 @@
 /area/rogue/indoors/town/garrison)
 "Dl" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -7411,7 +7083,6 @@
 /area/rogue/indoors/town/church/chapel)
 "Dp" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -7467,21 +7138,18 @@
 /area/rogue/indoors/town/garrison)
 "DA" = (
 /obj/effect/landmark/start/guardsman{
-	icon_state = "arrow";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "DB" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "DC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile{
@@ -7490,7 +7158,6 @@
 /area/rogue/indoors/town/garrison)
 "DD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/tile{
@@ -7552,12 +7219,9 @@
 "DO" = (
 /obj/structure/fluff/walldeco/innsign{
 	alpha = 200;
-	layer = 4.1;
-	level = 2;
 	pixel_y = -15
 	},
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -7572,14 +7236,12 @@
 /area/rogue/outdoors/town/roofs)
 "DR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "DS" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -7589,21 +7251,18 @@
 /area/rogue/indoors/town)
 "DU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "DV" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 9
 	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town)
 "DW" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/tilerg,
@@ -7654,7 +7313,6 @@
 /area/rogue/indoors/town/church)
 "Ef" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -7722,28 +7380,24 @@
 /area/rogue/indoors/town/tavern)
 "Ep" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "Eq" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "Er" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "Es" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -7817,7 +7471,6 @@
 /area/rogue/indoors/town/church)
 "EF" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/machinery/light/rogue/torchholder/r,
@@ -7832,13 +7485,11 @@
 /area/rogue/indoors/town/church)
 "EI" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 4
 	},
 /area/rogue/indoors/town/church)
 "EJ" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 8
 	},
 /area/rogue/indoors/town/church)
@@ -7874,18 +7525,15 @@
 /area/rogue/indoors/town/tavern)
 "ER" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs)
 "ES" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -7904,13 +7552,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"EX" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/garrison)
 "EY" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -7927,14 +7568,12 @@
 /area/rogue/indoors/town/church)
 "Fb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "Fc" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
@@ -7945,11 +7584,6 @@
 "Fe" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/church)
-"Ff" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
 /area/rogue/indoors/town/church)
 "Fg" = (
 /obj/structure/table/wood{
@@ -7984,15 +7618,12 @@
 /area/rogue)
 "Fm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue)
 "Fn" = (
-/obj/structure/table/wood{
-	layer = 2.8
-	},
+/obj/structure/table/wood,
 /obj/item/rogueweapon/sickle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue)
@@ -8019,7 +7650,6 @@
 /area/rogue/indoors/town/tavern)
 "Fs" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8028,7 +7658,6 @@
 /area/rogue/outdoors/town/roofs)
 "Ft" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/carpet,
@@ -8044,16 +7673,13 @@
 /area/rogue/indoors/town)
 "Fv" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "Fw" = (
 /obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "Fx" = (
 /obj/structure/table/wood{
@@ -8085,7 +7711,6 @@
 /area/rogue/indoors/town/church)
 "FB" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -8125,9 +7750,7 @@
 /area/rogue/indoors/town/church)
 "FG" = (
 /obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "FH" = (
 /obj/structure/bars/grille,
@@ -8147,15 +7770,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue)
 "FK" = (
-/obj/structure/table/wood{
-	layer = 2.8
-	},
+/obj/structure/table/wood,
 /obj/item/natural/stone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue)
 "FL" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8189,7 +7809,6 @@
 /area/rogue/indoors/town/tavern)
 "FQ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/adventurer{
@@ -8206,31 +7825,23 @@
 /area/rogue/outdoors/town/roofs)
 "FT" = (
 /obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "FU" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "FV" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rope/chain,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "FW" = (
 /obj/structure/closet/crate/chest,
 /obj/item/quiver/bolts,
 /obj/item/rogueweapon/flail/sflail,
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "FX" = (
 /obj/structure/mineral_door/wood{
@@ -8242,14 +7853,12 @@
 /area/rogue/indoors/town/garrison)
 "FY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "FZ" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8274,9 +7883,7 @@
 /obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "Ge" = (
 /obj/structure/bed/rogue/shit,
@@ -8290,7 +7897,6 @@
 /area/rogue)
 "Gg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -8303,7 +7909,6 @@
 /area/rogue/indoors/town/tavern)
 "Gi" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -8314,7 +7919,6 @@
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -8333,14 +7937,12 @@
 	dir = 4
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "Gm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/effect/landmark/start/adventurer{
@@ -8350,7 +7952,6 @@
 /area/rogue/indoors/town/tavern)
 "Gn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8359,7 +7960,6 @@
 /area/rogue)
 "Go" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -8372,7 +7972,6 @@
 /area/rogue/indoors/town/tavern)
 "Gq" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /obj/effect/landmark/start/villager{
@@ -8382,14 +7981,12 @@
 /area/rogue/indoors/town/tavern)
 "Gr" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "Gs" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -8410,7 +8007,6 @@
 /area/rogue/outdoors/town/roofs)
 "Gx" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8428,7 +8024,6 @@
 /area/rogue/indoors/town/tavern)
 "GB" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -8449,7 +8044,6 @@
 	icon_state = "cobweb2"
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8472,7 +8066,6 @@
 /area/rogue/indoors/town/tavern)
 "GL" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -8541,7 +8134,6 @@
 /area/rogue/indoors/town/tavern)
 "GX" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8564,21 +8156,18 @@
 /area/rogue/indoors/town/tavern)
 "Hc" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "Hd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 2
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "He" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -8588,7 +8177,6 @@
 /area/rogue/indoors/town/shop)
 "Hh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/metal,
@@ -8601,7 +8189,6 @@
 /area/rogue/outdoors/town/roofs)
 "Hj" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8617,7 +8204,6 @@
 /area/rogue/outdoors/town/roofs)
 "Hl" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 4;
 	pixel_x = -9
 	},
@@ -8650,7 +8236,6 @@
 /area/rogue/indoors/town/tavern)
 "Hq" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -8684,12 +8269,9 @@
 /area/rogue/indoors/town/garrison)
 "HA" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "HB" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -8712,35 +8294,25 @@
 "HE" = (
 /obj/structure/closet/crate/chest,
 /obj/item/book/rogue/law,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "HF" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "HG" = (
 /obj/structure/bookcase/random,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "HH" = (
 /obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "HI" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/powder,
 /obj/item/roguekey/merchant,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "HJ" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -8755,7 +8327,6 @@
 /area/rogue/indoors/town/dwarfin)
 "HL" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8797,7 +8368,6 @@
 /area/rogue/indoors/town)
 "HS" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8815,7 +8385,6 @@
 /area/rogue/indoors/town/shop)
 "HV" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8829,7 +8398,6 @@
 /area/rogue/indoors/town/dwarfin)
 "HX" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -8845,7 +8413,6 @@
 "Ia" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/weaponsmith{
-	icon_state = "arrow";
 	dir = 8
 	},
 /obj/item/bedsheet/rogue/cloth,
@@ -8855,7 +8422,6 @@
 /area/rogue/indoors/town/dwarfin)
 "Ib" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -8866,7 +8432,6 @@
 /area/rogue/indoors/town/dwarfin)
 "Id" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/effect/landmark/latejoin,
@@ -8892,13 +8457,11 @@
 /area/rogue/indoors/town/shop)
 "Ig" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "Ih" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8917,7 +8480,6 @@
 /area/rogue/indoors/town/dwarfin)
 "Ij" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -8936,9 +8498,7 @@
 	},
 /area/rogue/indoors/town)
 "In" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "Io" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -9046,16 +8606,12 @@
 /area/rogue/indoors/town/garrison)
 "IK" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "IL" = (
 /obj/structure/closet/crate/chest,
 /obj/item/roguegem/green,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "IM" = (
 /obj/structure/table/wood{
@@ -9069,7 +8625,6 @@
 /area/rogue/outdoors/mountains)
 "IN" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9090,7 +8645,6 @@
 /area/rogue/outdoors/mountains)
 "IR" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9105,7 +8659,6 @@
 /area/rogue/outdoors/mountains)
 "IU" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet,
@@ -9119,7 +8672,6 @@
 /area/rogue/indoors/town)
 "IX" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9154,7 +8706,6 @@
 /area/rogue/outdoors/town/roofs)
 "Je" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/rooftop{
@@ -9163,13 +8714,11 @@
 /area/rogue/outdoors/town/roofs)
 "Jf" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
 "Jg" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9186,7 +8735,6 @@
 /area/rogue/indoors/town/shop)
 "Jj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -9233,14 +8781,12 @@
 /area/rogue/indoors/town/dwarfin)
 "Js" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains)
 "Jt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -9254,21 +8800,18 @@
 /area/rogue/indoors/town/dwarfin)
 "Jv" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin)
 "Jw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/dwarfin)
 "Jx" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
@@ -9307,7 +8850,6 @@
 /area/rogue/indoors/town)
 "JD" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop,
@@ -9319,7 +8861,6 @@
 /area/rogue/indoors/town/dwarfin)
 "JF" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4;
 	lockid = "townroom1"
 	},
@@ -9327,7 +8868,6 @@
 /area/rogue/indoors/town/dwarfin)
 "JG" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -9336,14 +8876,12 @@
 /area/rogue/indoors/town/dwarfin)
 "JH" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "JI" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -9453,7 +8991,6 @@
 /area/rogue/indoors/town/magician)
 "Kh" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood,
@@ -9497,7 +9034,6 @@
 /area/rogue/indoors/town/tavern)
 "Kq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9556,7 +9092,6 @@
 /area/rogue/indoors/town/magician)
 "KA" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -9642,15 +9177,13 @@
 /area/rogue/indoors/town/magician)
 "KN" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/magician)
 "KO" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town)
 "KP" = (
@@ -9669,7 +9202,6 @@
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4;
 	pixel_x = 8;
 	layer = 2.8
@@ -9678,7 +9210,6 @@
 /area/rogue/indoors/town/church)
 "KT" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -9688,9 +9219,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
 "KV" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "KW" = (
 /obj/structure/closet/crate/roguecloset,
@@ -9708,7 +9237,6 @@
 /area/rogue/outdoors/town)
 "KY" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -9719,7 +9247,6 @@
 /area/rogue/indoors/town/church)
 "La" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -9743,14 +9270,12 @@
 /area/rogue/indoors/town/church)
 "Lc" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
 "Ld" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -9819,16 +9344,14 @@
 /area/rogue/outdoors/town)
 "Lq" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
 "Lr" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/stockpile,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "Ls" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church)
@@ -9885,14 +9408,11 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
 "LE" = (
-/obj/machinery/light/rogue/chand{
-	pixel_x = -10
-	},
+/obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
 "LF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -9908,9 +9428,7 @@
 /area/rogue/indoors/town/tavern)
 "LI" = (
 /obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "LJ" = (
 /obj/structure/fluff/clock,
@@ -9918,7 +9436,6 @@
 /area/rogue/indoors/town/tavern)
 "LK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -9938,8 +9455,7 @@
 "LN" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town)
 "LO" = (
@@ -9957,7 +9473,6 @@
 /area/rogue/indoors/town/tavern)
 "LQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -9983,14 +9498,12 @@
 /area/rogue/outdoors/town)
 "LV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church)
 "LW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -10006,7 +9519,6 @@
 /area/rogue/outdoors/beach)
 "LZ" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
@@ -10016,14 +9528,12 @@
 /area/rogue/outdoors/town)
 "Ma" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "Mb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -10033,11 +9543,9 @@
 /area/rogue/indoors/town/tavern)
 "Md" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -10066,7 +9574,6 @@
 /area/rogue/indoors/town/tavern)
 "Mj" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /obj/effect/landmark/start/villager{
@@ -10080,7 +9587,6 @@
 /area/rogue/indoors/town/tavern)
 "Ml" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -10090,7 +9596,6 @@
 /area/rogue/indoors/town/church)
 "Mn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10122,7 +9627,6 @@
 /area/rogue/indoors/town/church)
 "Ms" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -10153,9 +9657,7 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church)
 "Mz" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/outdoors/mountains)
 "MA" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -10176,7 +9678,6 @@
 /area/rogue/indoors/town/tavern)
 "ME" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/wood{
@@ -10230,8 +9731,7 @@
 "MQ" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town)
 "MR" = (
@@ -10268,7 +9768,6 @@
 /area/rogue/indoors/town/tavern)
 "MX" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -10289,7 +9788,6 @@
 /area/rogue/indoors/town/tavern)
 "Nb" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10299,7 +9797,6 @@
 /area/rogue/indoors/town/tavern)
 "Nc" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10325,7 +9822,6 @@
 /area/rogue/indoors/town/tavern)
 "Nf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10339,7 +9835,6 @@
 /area/rogue/indoors/town/tavern)
 "Nh" = (
 /obj/structure/mineral_door/wood{
-	locked = 0;
 	lockid = "tavern";
 	name = "MEETING ROOM"
 	},
@@ -10381,7 +9876,6 @@
 /area/rogue/indoors/town/manor)
 "Nn" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10397,12 +9891,10 @@
 /area/rogue/indoors/town/tavern)
 "Nq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/indoors/town/shop)
 "Nr" = (
@@ -10447,7 +9939,6 @@
 /area/rogue/indoors/town/shop)
 "Nz" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
@@ -10474,7 +9965,6 @@
 /area/rogue/outdoors/mountains)
 "ND" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/rooftop{
@@ -10497,7 +9987,6 @@
 /area/rogue)
 "NG" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -10515,7 +10004,6 @@
 /area/rogue/indoors/town/manor)
 "NJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10528,7 +10016,6 @@
 /area/rogue/indoors/town/tavern)
 "NL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -10562,7 +10049,6 @@
 /area/rogue/indoors/town/tavern)
 "NR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10571,7 +10057,6 @@
 /area/rogue/outdoors/beach)
 "NS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/landmark/latejoin,
@@ -10613,19 +10098,16 @@
 /area/rogue/indoors)
 "Od" = (
 /obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 0;
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement)
 "Oe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10634,7 +10116,6 @@
 /area/rogue/indoors/town)
 "Of" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10717,7 +10198,6 @@
 /area/rogue/indoors/town/garrison)
 "OB" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -10738,7 +10218,6 @@
 /area/rogue/outdoors/rtfield)
 "OH" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -10753,12 +10232,10 @@
 /area/rogue/indoors/town/garrison)
 "OJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10781,7 +10258,6 @@
 /area/rogue/outdoors/beach)
 "ON" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -10806,9 +10282,7 @@
 	icon_state = "longtable_mid";
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "OS" = (
 /turf/open/floor/rogue/blocks{
@@ -10817,7 +10291,6 @@
 /area/rogue/under/town/basement)
 "OU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -10860,7 +10333,6 @@
 /area/rogue/indoors/town)
 "Pd" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/center,
@@ -10891,15 +10363,12 @@
 /area/rogue/outdoors/town)
 "Pm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10915,7 +10384,6 @@
 /area/rogue/indoors/town)
 "Pp" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/effect/landmark/latejoin,
@@ -10928,19 +10396,15 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "Pr" = (
-/obj/structure/fluff/walldeco/wantedposter{
-	pixel_y = 32
-	},
+/obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "Ps" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks,
@@ -10971,16 +10435,12 @@
 /area/rogue/indoors/town/shop)
 "PC" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/effect/landmark/start/vagrant{
-	icon_state = "arrow";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "PD" = (
 /turf/open/floor/rogue/carpet/lord/right{
@@ -10989,15 +10449,12 @@
 /area/rogue/indoors/town/manor)
 "PE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11009,7 +10466,6 @@
 	pixel_y = 26
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11036,7 +10492,6 @@
 /area/rogue/indoors/town)
 "PJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11053,8 +10508,7 @@
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
@@ -11122,11 +10576,9 @@
 /area/rogue/under/town/basement)
 "PU" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -11153,14 +10605,12 @@
 /area/rogue/indoors/town/dwarfin)
 "Qa" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "Qb" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 8
 	},
 /area/rogue/outdoors/rtfield)
@@ -11169,7 +10619,6 @@
 /area/rogue/indoors/town/church)
 "Qd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11193,7 +10642,6 @@
 /area/rogue/indoors/town/manor)
 "Qi" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /turf/open/floor/rogue/church,
@@ -11247,14 +10695,12 @@
 /area/rogue/indoors/town)
 "Qu" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "Qw" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -11302,7 +10748,6 @@
 "QE" = (
 /obj/structure/floordoor/gatehatch/inner,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -11314,7 +10759,6 @@
 	},
 /obj/item/candle/skull,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile{
@@ -11323,7 +10767,6 @@
 /area/rogue/indoors/town/manor)
 "QG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -11354,14 +10797,12 @@
 	icon_state = "redcouch2"
 	},
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "QO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11375,7 +10816,6 @@
 "QQ" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -11386,7 +10826,6 @@
 /area/rogue/indoors/town/shop)
 "QT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -11410,16 +10849,12 @@
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
 "Rf" = (
 /obj/machinery/light/rogue/firebowl,
 /obj/structure/roguemachine/camera/left,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "Rg" = (
 /obj/structure/table/wood{
@@ -11445,7 +10880,6 @@
 /area/rogue/outdoors/rtfield)
 "Rk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -11498,7 +10932,6 @@
 /area/rogue/outdoors/town)
 "Ru" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11535,9 +10968,7 @@
 /area/rogue/indoors/town/church/chapel)
 "RC" = (
 /obj/structure/table/wood,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "RD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -11547,7 +10978,6 @@
 /area/rogue/indoors/town/magician)
 "RE" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -11587,7 +11017,6 @@
 /area/rogue/indoors/town/bath)
 "RJ" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/church,
@@ -11601,7 +11030,6 @@
 /area/rogue/indoors/town/manor)
 "RM" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 0;
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -11650,7 +11078,6 @@
 /area/rogue/indoors/town/manor)
 "RW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11691,11 +11118,9 @@
 /area/rogue/indoors/town/manor)
 "Sd" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -11729,16 +11154,12 @@
 /area/rogue/indoors/town/manor)
 "Sj" = (
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "Sk" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -11750,7 +11171,6 @@
 /area/rogue/outdoors/town)
 "Sm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -11760,9 +11180,7 @@
 /obj/structure/mineral_door/wood/window{
 	lockid = "woodsm"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "So" = (
 /obj/structure/fluff/statue/gargoyle,
@@ -11778,7 +11196,6 @@
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
@@ -11799,8 +11216,7 @@
 /area/rogue/outdoors/rtfield)
 "Sx" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/indoors/town/manor)
@@ -11822,9 +11238,7 @@
 /area/rogue/indoors/town/bath)
 "SC" = (
 /obj/item/reagent_containers/glass/pot,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "SD" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -11837,7 +11251,6 @@
 "SF" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	icon_state = "donjondir";
 	locked = 1;
 	lockid = "manor";
 	name = "Throne Room"
@@ -11859,12 +11272,9 @@
 /area/rogue/outdoors/rtfield)
 "SL" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "SM" = (
 /obj/structure/flora/newtree,
@@ -11904,7 +11314,6 @@
 /area/rogue/indoors/town/manor)
 "ST" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/effect/landmark/latejoin,
@@ -11923,7 +11332,6 @@
 /area/rogue/outdoors/rtfield)
 "SW" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -11974,14 +11382,12 @@
 /area/rogue/indoors/town/church)
 "Te" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach)
 "Tf" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/plating/ashplanet/rocky,
@@ -11991,7 +11397,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks,
@@ -12013,19 +11418,16 @@
 /area/rogue/indoors/town/shop)
 "Tl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "Tm" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -12090,7 +11492,6 @@
 /area/rogue/outdoors/town)
 "Tz" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -12119,8 +11520,7 @@
 /area/rogue/indoors/town/manor)
 "TI" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	icon_state = "wooddir"
+	dir = 1
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
@@ -12144,7 +11544,6 @@
 /area/rogue/indoors/town/manor)
 "TM" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -12194,7 +11593,6 @@
 /area/rogue/outdoors/town)
 "TW" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /obj/effect/landmark/latejoin,
@@ -12204,7 +11602,6 @@
 /area/rogue/outdoors/beach)
 "TX" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12238,14 +11635,12 @@
 "Ue" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "Uf" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -12278,7 +11673,6 @@
 /area/rogue/indoors/town/manor)
 "Ul" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -12315,15 +11709,12 @@
 /area/rogue/outdoors/town)
 "Ut" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12335,7 +11726,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -12347,7 +11737,6 @@
 /area/rogue/under/town/basement)
 "Ux" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -12394,12 +11783,10 @@
 /area/rogue/indoors/town/tavern)
 "UI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -12418,7 +11805,6 @@
 /area/rogue/outdoors/town)
 "UL" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12427,7 +11813,6 @@
 /area/rogue/indoors/town/tavern)
 "UM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -12443,9 +11828,7 @@
 /area/rogue/outdoors/town)
 "UP" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "UQ" = (
 /obj/structure/table/wood{
@@ -12459,7 +11842,6 @@
 /area/rogue/indoors/town/manor)
 "UR" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -12530,8 +11912,7 @@
 /area/rogue/indoors/town/manor)
 "Vb" = (
 /obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/sewer)
@@ -12541,14 +11922,12 @@
 /area/rogue/indoors/town/manor)
 "Ve" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/beach)
 "Vf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -12566,7 +11945,6 @@
 /area/rogue/outdoors/town)
 "Vi" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12597,8 +11975,7 @@
 /area/rogue/indoors/town/manor)
 "Vn" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -12617,7 +11994,6 @@
 /area/rogue/outdoors/town)
 "Vs" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt,
@@ -12631,20 +12007,16 @@
 /area/rogue/under/town/basement)
 "Vv" = (
 /obj/structure/fluff/walldeco/goblet{
-	icon_state = "goblet";
 	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "Vx" = (
 /obj/structure/fermenting_barrel/random/beer,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "Vy" = (
 /obj/structure/chair/bench/couch,
@@ -12673,11 +12045,9 @@
 "VD" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -12714,13 +12084,11 @@
 /area/rogue/indoors/town/manor)
 "VL" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
 "VM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12733,7 +12101,6 @@
 /area/rogue/outdoors/rtfield)
 "VO" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
-	icon_state = "decostone-e";
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
@@ -12779,11 +12146,9 @@
 /area/rogue/outdoors/rtfield)
 "Wa" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12792,7 +12157,6 @@
 /area/rogue/outdoors/beach)
 "Wb" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 5
 	},
 /turf/open/floor/rogue/wood,
@@ -12804,11 +12168,9 @@
 "Wf" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder{
@@ -12858,16 +12220,13 @@
 /area/rogue/indoors/town/manor)
 "Wn" = (
 /obj/structure/bars/pipe{
-	icon_state = "pipe";
 	dir = 4;
 	pixel_x = -9
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "Wo" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "Wp" = (
 /obj/structure/table/wood{
@@ -12889,7 +12248,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/blocks,
@@ -12911,14 +12269,12 @@
 /area/rogue/indoors/town)
 "Ww" = (
 /obj/structure/stairs{
-	dir = 1;
-	icon_state = "stairs"
+	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "Wz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/standing,
@@ -12949,7 +12305,6 @@
 /area/rogue/outdoors/town)
 "WF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -12972,15 +12327,12 @@
 /area/rogue/indoors/town/manor)
 "WK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13018,7 +12370,6 @@
 "WQ" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned,
@@ -13030,7 +12381,6 @@
 /area/rogue/under/town/basement)
 "WS" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -13047,7 +12397,6 @@
 /area/rogue/indoors/town/manor)
 "WW" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 4
 	},
 /turf/closed,
@@ -13097,7 +12446,6 @@
 /area/rogue/indoors/town/manor)
 "Xh" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -13132,11 +12480,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"Xp" = (
-/turf/open/floor/rogue/tile/masonic{
-	dir = 2
-	},
-/area/rogue/indoors/town/manor)
 "Xq" = (
 /obj/structure/table/wood{
 	icon_state = "largetable";
@@ -13147,7 +12490,6 @@
 /area/rogue/indoors/town/manor)
 "Xr" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/stone,
@@ -13208,7 +12550,6 @@
 	dir = 5
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -13243,16 +12584,13 @@
 /area/rogue/outdoors/rtfield)
 "XJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
 "XK" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/shop)
 "XL" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -13420,7 +12758,6 @@
 /area/rogue/indoors/town/garrison)
 "Yy" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -13434,9 +12771,7 @@
 /area/rogue/indoors/town/dwarfin)
 "YA" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "YB" = (
 /obj/effect/landmark/start/prisoner,
@@ -13444,7 +12779,6 @@
 /area/rogue/under/town/basement)
 "YC" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile{
@@ -13453,7 +12787,6 @@
 /area/rogue/indoors/town/manor)
 "YD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -13475,7 +12808,6 @@
 /area/rogue/indoors/town/shop)
 "YI" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile{
@@ -13547,7 +12879,6 @@
 	pixel_y = -1
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -13578,7 +12909,6 @@
 /area/rogue/outdoors/town)
 "YZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13654,7 +12984,6 @@
 /area/rogue/outdoors/rtfield)
 "Zn" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -13728,7 +13057,6 @@
 /area/rogue/indoors/town/tavern)
 "ZD" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -13752,7 +13080,6 @@
 /area/rogue/indoors/town)
 "ZI" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /obj/effect/landmark/latejoin,
@@ -13773,13 +13100,10 @@
 /area/rogue/indoors/town/manor)
 "ZN" = (
 /obj/item/roguebin/trash,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town)
 "ZO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -72408,7 +71732,7 @@ zi
 rc
 eG
 eG
-eL
+Lr
 eL
 VL
 wc
@@ -74760,9 +74084,9 @@ Qh
 pX
 gk
 fH
-Xp
+yd
 ga
-Xp
+yd
 ga
 yd
 ga
@@ -74844,8 +74168,8 @@ gg
 eS
 eS
 Tg
-jQ
-jQ
+LG
+LG
 Wz
 jP
 wq
@@ -85777,7 +85101,7 @@ iD
 iD
 iD
 iD
-nZ
+iB
 Yk
 TR
 er
@@ -85934,7 +85258,7 @@ iD
 iD
 iD
 WS
-nZ
+iB
 Yk
 TR
 er
@@ -96152,7 +95476,7 @@ xB
 xB
 xB
 Bf
-BB
+tB
 BB
 BB
 CE
@@ -97372,7 +96696,7 @@ xN
 xN
 xN
 ga
-Xp
+yd
 ga
 xN
 xN
@@ -97528,7 +96852,7 @@ RU
 xN
 xN
 xN
-Xp
+yd
 ga
 yd
 xN
@@ -97686,7 +97010,7 @@ xN
 ZM
 xN
 ga
-Xp
+yd
 ga
 xN
 xN
@@ -103226,7 +102550,7 @@ Cv
 Zt
 jN
 Ez
-EX
+TI
 Fw
 FT
 jN
@@ -103692,8 +103016,8 @@ lm
 lm
 jN
 Cx
-CN
-CN
+Cw
+Cw
 DD
 jN
 CO
@@ -109351,7 +108675,7 @@ Ei
 zG
 nb
 nb
-Ff
+Zl
 zG
 Gt
 Gt
@@ -109508,7 +108832,7 @@ nb
 EJ
 nb
 FD
-Ff
+Zl
 zG
 Gv
 Gt
@@ -109665,7 +108989,7 @@ nb
 EK
 Fe
 FE
-Ff
+Zl
 EJ
 Gt
 Gt
@@ -109822,7 +109146,7 @@ nb
 EI
 nb
 FF
-Ff
+Zl
 zG
 Gt
 Gt
@@ -109977,9 +109301,9 @@ Dr
 Dq
 Ej
 zG
-Ff
+Zl
 FG
-Ff
+Zl
 EI
 xF
 xF
@@ -118787,7 +118111,7 @@ er
 er
 er
 Ns
-Lr
+KQ
 JY
 JY
 JY
@@ -120056,7 +119380,7 @@ Nr
 Nr
 er
 er
-Lr
+KQ
 JY
 JY
 JY
@@ -120200,7 +119524,7 @@ er
 er
 er
 er
-Lr
+KQ
 JY
 Mx
 JY
@@ -121612,7 +120936,7 @@ er
 er
 er
 Ns
-Lr
+KQ
 JY
 JY
 JY
@@ -121779,7 +121103,7 @@ JZ
 JV
 JX
 KO
-Lr
+KQ
 JY
 JY
 JY
@@ -123479,7 +122803,7 @@ er
 er
 er
 KO
-Lr
+KQ
 JY
 Kc
 KO
@@ -123496,7 +122820,7 @@ KO
 KO
 KO
 Nr
-Lr
+KQ
 JY
 JY
 JY
@@ -124101,7 +123425,7 @@ er
 er
 er
 KO
-Lr
+KQ
 JY
 JY
 JY
@@ -124292,7 +123616,7 @@ sF
 JV
 Nr
 Nr
-Lr
+KQ
 JY
 Kc
 Nr
@@ -124414,7 +123738,7 @@ er
 er
 KO
 KO
-Lr
+KQ
 JZ
 LM
 lF
@@ -124570,7 +123894,7 @@ er
 er
 er
 KO
-Lr
+KQ
 JZ
 LD
 lF
@@ -125671,7 +124995,7 @@ er
 Lo
 Lo
 Lo
-Lr
+KQ
 JY
 JY
 JY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Added a Stockpiler in the Inn's Kitchen and one in the Keep next to the Shylock. Allowing easier access to it.
Only map changes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Stockpilers are a very useful tool. But currently, only the Smiths can properly make use of it. 
There is one public one, but that kinda sucks to get to when you are busy doing what your role is supposed to do.

It mainly will help out kitchen roles a ton, being able to easily buy grain from the stockpile.
But that won't kill RP between kitchen roles and farmer roles, being that every food item besides grain, still needs to be bought directly from farmers.

Also, first PR, yell if I fucked up.

![Screenshot 2024-05-09 023512](https://github.com/Blackstone-SS13/BLACKSTONE/assets/155458128/9e6171cf-35d5-410c-a8a9-e306c80a6bfb)
![Screenshot 2024-05-09 023555](https://github.com/Blackstone-SS13/BLACKSTONE/assets/155458128/be3522c4-1425-4f54-82f3-00e171ffac3b)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
