### PR TITLE
adds custom locks

### DIFF
--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -281,7 +281,8 @@
 
 /obj/item/roguekey/custom/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))
-		name = input(user, "What would you name this key?") as text
+		name = (input(user, "What would you name this key?") as text) + " key"
+		to_chat(user, "<span class='notice'>You rename the key to [name].</span>")
 
 //custom key blank
 /obj/item/customblank //i'd prefer not to make a seperate item for this honestly
@@ -296,21 +297,21 @@
 /obj/item/customblank/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))
 		var/input = input(user, "What would you like to set the key ID to?") as num
-		lockid = 10000 + input //having custom lock ids start with cd prevents people from cloning keys that they normally don't have access to. same thing is done with customlock
+		lockid = 10000 + input //having custom lock ids start at 10000 leaves it outside the range that opens normal doors, so you can't make a key that randomly unlocks existing key ids like the church
 
 /obj/item/customblank/attack_right(mob/user)
 	if(istype(user.get_active_held_item(), /obj/item/roguekey))
 		var/obj/item/roguekey/held = user.get_active_held_item()
 		src.lockid = held.lockhash
-		to_chat(user, "<span class='small'>You trace the teeth from [held] to [src].</span>")
+		to_chat(user, "<span class='notice'>You trace teeth from [held] to [src].</span>")
 	if(istype(user.get_active_held_item(), /obj/item/customlock))
 		var/obj/item/customlock/held = user.get_active_held_item()
 		src.lockid = held.lockid
-		to_chat(user, "<span class='small'>You fine tune the [src] to the lock's internals.</span>")
+		to_chat(user, "<span class='notice'>You fine tune [src] to the lock's internals.</span>")
 	if(istype(user.get_active_held_item(), /obj/item/rogueweapon/hammer) && src.lockid != null)
 		var/obj/item/roguekey/custom/F = new (src.loc)
 		F.lockhash = src.lockid
-		to_chat(user, "<span class='small'>You finish the [F].</span>")
+		to_chat(user, "<span class='notice'>You finish [F].</span>")
 		qdel(src)
 	
 
@@ -327,33 +328,33 @@
 /obj/item/customlock/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))
 		var/input = input(user, "What would you like to set the key ID to?") as num
-		lockid = 10000 + input //having custom lock ids start with cd prevents people from cloning keys that they normally don't have access to. same thing is done with customblank
+		lockid = 10000 + input //same deal as the customkey
 	if(istype(I, /obj/item/roguekey))
 		var/obj/item/roguekey/ID = I
 		if(ID.lockhash == src.lockid)
-			to_chat(user, "<span class='small'>[I] twists cleanly in [src].</span>")
+			to_chat(user, "<span class='notice'>[I] twists cleanly in [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>[I] jams in [src],</span>")
 	if(istype(I, /obj/item/customblank))
 		var/obj/item/customblank/ID = I
 		if(ID.lockid == src.lockid)
-			to_chat(user, "<span class='small'>[I] twists cleanly in [src],</span>") //this makes no sense since the teeth aren't formed yet but i want people to be able to check whether the locks theyre making actually fit
+			to_chat(user, "<span class='notice'>[I] twists cleanly in [src],</span>") //this makes no sense since the teeth aren't formed yet but i want people to be able to check whether the locks theyre making actually fit
 		else
 			to_chat(user, "<span class='warning'>[I] jams in [src].</span>")
 
 /obj/item/customlock/attack_right(mob/user)
-	if(istype(user.get_active_held_item(), /obj/item/roguekey))
+	if(istype(user.get_active_held_item(), /obj/item/roguekey))//i need to figure out how to avoid these massive if/then trees, this sucks
 		var/obj/item/roguekey/held = user.get_active_held_item()
 		src.lockid = held.lockid
-		to_chat(user, "<span class='small'>You align the lock's internals to [held].</span>") //locks for non-custom keys
+		to_chat(user, "<span class='notice'>You align the lock's internals to [held].</span>") //locks for non-custom keys
 	if(istype(user.get_active_held_item(), /obj/item/customblank))
 		var/obj/item/customblank/held = user.get_active_held_item()
 		src.lockid = held.lockid
-		to_chat(user, "<span class='small'>You align the lock's internals to [held].</span>")
+		to_chat(user, "<span class='notice'>You align the lock's internals to [held].</span>")
 	if(istype(user.get_active_held_item(), /obj/item/rogueweapon/hammer) && src.lockid != null)
 		var/obj/item/customlock/finished/F = new (src.loc)
 		F.lockid = src.lockid
-		to_chat(user, "<span class='small'>You finish [F].</span>")
+		to_chat(user, "<span class='notice'>You finish [F].</span>")
 		qdel(src)
 
 //finished lock
@@ -365,10 +366,11 @@
 /obj/item/customlock/finished/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/hammer))
 		src.holdname = input(user, "What would you like to name this?", "") as text
+		to_chat(user, "<span class='notice'>You label the [name].</span>")
 	else
 		..()
 
-/obj/item/customlock/finished/attack_right(mob/user)//does nothing
+/obj/item/customlock/finished/attack_right(mob/user)//does nothing. probably better ways to do this but whatever
 
 /obj/item/customlock/finished/attack_obj(obj/structure/K, mob/living/user)
 	if(istype(K, /obj/structure/closet))
@@ -379,8 +381,8 @@
 			KE.keylock = TRUE
 			KE.lockhash = src.lockid
 			if(src.holdname != null)
-				KE.name = (" " + src.holdname + "KE.name")
-			to_chat(user, "<span class='small'>You add [src] to the [K].</span>")
+				KE.name = (src.holdname + " " + KE.name)
+			to_chat(user, "<span class='notice'>You add [src] to [K].</span>")
 			qdel(src)
 	if(istype(K, /obj/structure/mineral_door/wood/deadbolt))
 		var/obj/structure/mineral_door/wood/deadbolt/KE = K
@@ -391,7 +393,7 @@
 			KE.lockhash = src.lockid
 			if(src.holdname != null)
 				KE.name = src.holdname
-			to_chat(user, "<span class='small'>You add [src] to the [K].</span>")
+			to_chat(user, "<span class='notice'>You add [src] to [K].</span>")
 			qdel(src)
 			
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -302,10 +302,10 @@
 			playsound(src, 'sound/foley/doors/lockrattle.ogg', 100)
 
 /obj/structure/closet/proc/tool_interact(obj/item/W, mob/user)//returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
-	. = TRUE
+	. = FALSE
 	if(opened)
 		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
-			return
+			return TRUE
 
 
 

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -202,6 +202,7 @@
 	craftdiff = 0
 
 /obj/structure/closet/crate/chest/crafted
+	keylock = FALSE
 	sellprice = 6
 
 /datum/crafting_recipe/roguetown/structure/closet

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -94,3 +94,13 @@
 	name = "3x cogs"
 	req_bar = /obj/item/ingot/iron
 	created_item = list(/obj/item/roguegear, /obj/item/roguegear, /obj/item/roguegear)
+
+/datum/anvil_recipe/tools/locks
+	name = "5x locks"
+	req_bar = /obj/item/ingot/iron
+	created_item = list(/obj/item/customlock, /obj/item/customlock, /obj/item/customlock, /obj/item/customlock, /obj/item/customlock)
+
+/datum/anvil_recipe/tools/keys
+	name = "5x keys"
+	req_bar = /obj/item/ingot/iron
+	created_item = list(/obj/item/customblank, /obj/item/customblank, /obj/item/customblank, /obj/item/customblank, /obj/item/customblank)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

see title
you make locks and keys from iron bars, 5 per
you hit them with a hammer to set their ids, right click with a hammer to finish them
after you finish a lock, you can hit it with a hammer again to set a name to change your locked thing to
or hit a finished key with a hammer to change its name

you can right click between locks and keys to sync onto each other, which also works for pre-existing keys
this will definitely not have unforeseen consequences

## Why It's Good For The Game

because it's funny
also fixes a bug where you couldn't hit chests and lockers because roguetown coders lmao


https://github.com/Blackstone-SS13/BLACKSTONE/assets/59631103/1c8f008a-3dd1-4253-ad06-1e808f8d75fb

