### PR TITLE
Un-shadow bans female characters from every job in the game

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -367,7 +367,6 @@ SUBSYSTEM_DEF(job)
 
 	//Shuffle players and jobs
 	unassigned = shuffle(unassigned)
-	unassigned = sort_male_female(unassigned)
 
 	HandleFeedbackGathering()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes one line that assigns male characters jobs before assigning female characters in the remaining jobs. Tested locally.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently if a male character and a female character ready up for the same job, the male character wins every single roll for the job without fail. If you ever wanted to play as a female character in a highly contested job, your only options are to hope the stars align and no male characters roll for it, or just give up.

This should add more potential variety to the characters you'll come across in game and actually allow female characters a chance into the jobs they are not restricted from.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
