### PR TITLE
Make adminwho an admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -28,6 +28,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/deadmin,				/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/set_context_menu_enabled,
 	/client/proc/delete_player_book,
+	/client/proc/adminwho
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -92,6 +92,7 @@ GLOBAL_PROTECT(href_token)
 	if ((C = owner) || (C = GLOB.directory[target]))
 		disassociate()
 		C.verbs += /client/proc/readmin
+		C.verbs += /client/proc/adminwho
 
 /datum/admins/proc/associate(client/C)
 	if(IsAdminAdvancedProcCall())

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -236,6 +236,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		connecting_admin = TRUE
 	else if(GLOB.deadmins[ckey])
 		verbs += /client/proc/readmin
+		verbs += /client/proc/adminwho
 		connecting_admin = TRUE
 	if(CONFIG_GET(flag/autoadmin))
 		if(!GLOB.admin_datums[ckey])

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -102,10 +102,8 @@
 	
 	var/datum/admins/A = GLOB.deadmins[ckey]
 	if(!A)
-		A = GLOB.admin_datums[ckey]
-		if (!A)
-			if(!check_rights(R_ADMIN))
-				return
+		if(!check_rights(R_ADMIN))
+			return
 
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -99,9 +99,14 @@
 	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
-	if(!check_rights(R_ADMIN))
-		to_chat(src, "You do not have the rights to use this command.")
-		return
+	
+	var/datum/admins/A = GLOB.deadmins[ckey]
+	if(!A)
+		A = GLOB.admin_datums[ckey]
+		if (!A)
+			if(!check_rights(R_ADMIN))
+				return
+
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -95,13 +95,11 @@
 		msg += "<br><b>Whitelisted players:</b> [wled]"
 	to_chat(src, msg)
 
-/client/verb/adminwho()
+/client/proc/adminwho()
 	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
-	
-	if(!check_rights(R_ADMIN))
-		to_chat(src, "You do not have the rights to use this command.")
+	if(!holder)
 		return
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -99,8 +99,8 @@
 	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
-	if(!holder)
-		return
+	if(!check_rights(R_ADMIN))
+		to_chat(src, "You do not have the rights to use this command.")
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -101,6 +101,7 @@
 	set desc = "Lists all admins currently online."
 	if(!check_rights(R_ADMIN))
 		to_chat(src, "You do not have the rights to use this command.")
+		return
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

someone made this slop code for not letting people use the adminwho verb, why not just make it an admin verb

i guess they made it like that beacuse they wanted admins to be able to use it while being deadmin so i made it like the readmin command it appears if you deadmin

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes slopcode

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
