### PR TITLE
The Queen is now called the Queen Consort. A coronated Queen Consort/Princess/other female becomes the Queen

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -95,11 +95,14 @@ SUBSYSTEM_DEF(job)
 		player.mind.assigned_role = rank
 		unassigned -= player
 		job.current_positions++
-		if(job == "Queen")
+
+		if(rank == "Queen Consort") //making Queen if there's no King
 			var/datum/job/kingjob = GetJob("King")
-			if(SSticker.rulertype == "Queen" && kingjob.current_positions == 0)
+			if(kingjob.current_positions == 0)
+				SSticker.rulertype = "Queen"
 				player.mind.assigned_role = "King"
 				kingjob.current_positions++
+				
 		if(!latejoin)
 			if(player.client)
 				if(job.bypass_lastclass)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -95,14 +95,6 @@ SUBSYSTEM_DEF(job)
 		player.mind.assigned_role = rank
 		unassigned -= player
 		job.current_positions++
-
-		if(rank == "Queen Consort") //making Queen if there's no King
-			var/datum/job/kingjob = GetJob("King")
-			if(kingjob.current_positions == 0)
-				SSticker.rulertype = "Queen"
-				player.mind.assigned_role = "King"
-				kingjob.current_positions++
-				
 		if(!latejoin)
 			if(player.client)
 				if(job.bypass_lastclass)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -95,6 +95,11 @@ SUBSYSTEM_DEF(job)
 		player.mind.assigned_role = rank
 		unassigned -= player
 		job.current_positions++
+		if(job == "Queen")
+			var/datum/job/kingjob = GetJob("King")
+			if(SSticker.rulertype == "Queen" && kingjob.current_positions == 0)
+				player.mind.assigned_role = "King"
+				kingjob.current_positions++
 		if(!latejoin)
 			if(player.client)
 				if(job.bypass_lastclass)

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(treasury)
 		var/people_told = 0
 		for(var/mob/living/carbon/human/X in GLOB.human_list)
 			switch(X.job)
-				if("King", "Queen", "Steward", "Clerk")
+				if("King", "Steward", "Clerk")
 					people_told += 1
 					send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
 					if(people_told > 3)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -272,7 +272,7 @@ SUBSYSTEM_DEF(ticker)
 							continue
 				readied_jobs.Add(V)
 	if("Merchant" in readied_jobs)
-		if(("King" in readied_jobs) || ("Queen" in readied_jobs))
+		if(("King" in readied_jobs) || ("Queen Consort" in readied_jobs))
 			if("King" in readied_jobs)
 				rulertype = "King"
 			else
@@ -547,21 +547,12 @@ SUBSYSTEM_DEF(ticker)
 		CHECK_TICK
 
 /datum/controller/subsystem/ticker/proc/select_ruler()
-	switch(rulertype)
-		if("King")
-			for(var/mob/living/carbon/human/K in world)
-				if(istype(K, /mob/living/carbon/human/dummy))
-					continue
-				if(K.job == "King")
-					rulermob = K
-					return
-		if("Queen")
-			for(var/mob/living/carbon/human/Q in world)
-				if(istype(Q, /mob/living/carbon/human/dummy))
-					continue
-				if(Q.job == "Queen")
-					rulermob = Q
-					return
+	for(var/mob/living/carbon/human/K in world)
+		if(istype(K, /mob/living/carbon/human/dummy))
+			continue
+		if(K.job == "King")
+			rulermob = K
+			return
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/i in GLOB.new_player_list)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -271,12 +271,11 @@ SUBSYSTEM_DEF(ticker)
 							to_chat(player, "<span class='warning'>You cannot be [V] and thus are not considered.</span>")
 							continue
 				readied_jobs.Add(V)
-	if("Merchant" in readied_jobs)
-		if(("King" in readied_jobs) || ("Queen Consort" in readied_jobs))
-			if("King" in readied_jobs)
-				rulertype = "King"
-			else
-				rulertype = "Queen"
+	if(("King" in readied_jobs) || ("Queen Consort" in readied_jobs))
+		if("King" in readied_jobs)
+			rulertype = "King"
+		else
+			rulertype = "Queen"
 		/*	
 			// These else conditions stop the round from starting unless there is a merchant, king, and queen.
 		else

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -271,12 +271,6 @@ SUBSYSTEM_DEF(ticker)
 							to_chat(player, "<span class='warning'>You cannot be [V] and thus are not considered.</span>")
 							continue
 				readied_jobs.Add(V)
-		if("Merchant" in readied_jobs)
-			if(("King" in readied_jobs) || ("Queen" in readied_jobs))
-				if("King" in readied_jobs)
-					rulertype = "King"
-				else
-					rulertype = "Queen"
 		/*	
 			// These else conditions stop the round from starting unless there is a merchant, king, and queen.
 		else

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -271,11 +271,12 @@ SUBSYSTEM_DEF(ticker)
 							to_chat(player, "<span class='warning'>You cannot be [V] and thus are not considered.</span>")
 							continue
 				readied_jobs.Add(V)
-	if(("King" in readied_jobs) || ("Queen Consort" in readied_jobs))
-		if("King" in readied_jobs)
-			rulertype = "King"
-		else
-			rulertype = "Queen"
+		if("Merchant" in readied_jobs)
+			if(("King" in readied_jobs) || ("Queen" in readied_jobs))
+				if("King" in readied_jobs)
+					rulertype = "King"
+				else
+					rulertype = "Queen"
 		/*	
 			// These else conditions stop the round from starting unless there is a merchant, king, and queen.
 		else

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -184,7 +184,7 @@ SUBSYSTEM_DEF(vote)
 					if(H.stat != DEAD)
 						vote_power += 3
 					if(H.job)
-						var/list/list_of_powerful = list("King", "Queen", "Priest", "Steward", "Hand")
+						var/list/list_of_powerful = list("King", "Queen Consort", "Priest", "Steward", "Hand")
 						if(H.job in list_of_powerful)
 							vote_power += 5
 						else

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -47,7 +47,7 @@
 	name = "the Lord's crown."
 	targetitem = /obj/item/clothing/head/roguetown/crown/serpcrown
 	difficulty = 3
-	excludefromjob = list("King", "Queen", "Knight")
+	excludefromjob = list("King", "Queen Consort", "Knight")
 
 
 ////////////////////////////////////////////////////////////

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -107,7 +107,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampire Lord", "Extended", "
 	var/lord_dead = FALSE
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(H.mind)
-			if(H.job == "King" || H.job == "Queen")
+			if(H.job == "King")
 				lord_found = TRUE
 				if(H.stat == DEAD)
 					lord_dead = TRUE
@@ -199,7 +199,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampire Lord", "Extended", "
 	//BANDITS
 	banditgoal = rand(200,400)
 	restricted_jobs = list("King",
-	"Queen",
+	"Queen Consort",
 	"Merchant",
 	"Priest",
 	"Knight")
@@ -306,7 +306,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampire Lord", "Extended", "
 	restricted_jobs = list()
 
 /datum/game_mode/chaosmode/proc/pick_maniac()
-	restricted_jobs = list("King", "Queen")
+	restricted_jobs = list("King", "Queen Consort")
 	antag_candidates = get_players_for_role(ROLE_MANIAC)
 	var/datum/mind/villain = pick_n_take(antag_candidates)
 	if(villain)
@@ -333,7 +333,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampire Lord", "Extended", "
 /datum/game_mode/chaosmode/proc/pick_vampires()
 	var/vampsremaining = 3
 	restricted_jobs = list("King",
-	"Queen",
+	"Queen Consort",
 	"Dungeoneer",
 	"Witch Hunter",
 	"Confessor",

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -290,7 +290,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/lady
-	name = "Queen"
+	name = "Queen Consort"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/prince

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -50,7 +50,7 @@
 		user.visible_message("<span class='warning'>[user] points [src] at [target].</span>")
 		if(ishuman(user))
 			var/mob/living/carbon/human/HU = user
-			if((HU.job != "King") && (HU.job != "Queen"))
+			if((HU.job != "King") && (HU.job != "Queen Consort"))
 				return
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -884,7 +884,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/objective/vampirelord/infiltrate/two/check_completion()
 	var/datum/game_mode/chaosmode/C = SSticker.mode
-	var/list/noblejobs = list("King", "Queen", "Prince", "Princess", "Hand", "Steward")
+	var/list/noblejobs = list("King", "Queen Consort", "Prince", "Princess", "Hand", "Steward")
 	for(var/datum/mind/V in C.vampires)
 		if(V.current.job in noblejobs)
 			return TRUE

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -82,13 +82,9 @@
 				if(HL.mind.assigned_role == "King" || HL.mind.assigned_role == "Queen Consort")
 					HL.mind.assigned_role = "Towner"
 			if(HL.job == "King")
-				switch(HL.gender)
-					if("male")
-						HL.job.title = "King Emeritus"
-					if("female")
-						HL.job.title = "Queen Emeritus"
+				HL.job = "King Emeritus"
 			if(HL.job == "Queen Consort")
-				HL.job.title = "Queen Dowager"
+				HL.job = "Queen Dowager"
 
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "King"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -101,7 +101,7 @@
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "King"
 		HU.job = "King"
-		switch(HL.gender)
+		switch(HU.gender)
 			if("male")
 				SSticker.rulertype = "King"
 			if("female")

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -8,7 +8,6 @@
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = JCOLOR_CHURCH
-	f_title = "Priestess"
 	allowed_races = list("Humen", "Aasimar")
 	allowed_patrons = list("Astrata")
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals and you will preach their wisdom to any who still heed their will. The faithless are growing in number, it is up to you to shepard them to a Gods-fearing future."
@@ -76,30 +75,37 @@
 			continue
 		if(!istype(HU.head, /obj/item/clothing/head/roguetown/crown/serpcrown))
 			continue
+		
+		//Abdicate previous King
 		for(var/mob/living/carbon/human/HL in GLOB.human_list)
 			if(HL.mind)
 				if(HL.mind.assigned_role == "King")
-					HL.mind.assigned_role = "Ex-King"
+					switch(HL.gender)
+						if("male")
+							HL.mind.assigned_role = "King Emeritus"
+						if("female")
+							HL.mind.assigned_role = "Queen Emeritus"
 			if(HL.job == "King")
-				HL.job = "Ex-King"
+				switch(HL.gender)
+					if("male")
+						HL.mind.assigned_role = "King Emeritus"
+					if("female")
+						HL.mind.assigned_role = "Queen Emeritus"
+				HL.job = "King Emeritus"
 			if(HL.mind)
-				if(HL.mind.assigned_role == "Queen")
-					HL.mind.assigned_role = "Ex-Queen"
-			if(HL.job == "Queen")
-				HL.job = "Ex-Queen"
-		switch(HU.gender)
-			if("male")
-				HU.mind.assigned_role = "King"
-				HU.job = "King"
-			if("female")
-				HU.mind.assigned_role = "Queen"
-				HU.job = "Queen"
+				if(HL.mind.assigned_role == "Queen Consort")
+					HL.mind.assigned_role = "Queen Dowager"
+			if(HL.job == "Queen Consort")
+				HL.job = "Queen Dowager"
+
+		//Coronate new King (or Queen)
+		HU.mind.assigned_role = "King"
+		HU.job = "King"
 		SSticker.rulermob = HU
 		var/dispjob = mind.assigned_role
 		GLOB.badomens -= "nolord"
 		say("By the authority of the gods, I pronounce you Ruler of all Rockhill!")
 		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of ROGUETOWN!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
-		return
 
 /mob/living/carbon/human/proc/churchexcommunicate()
 	set name = "Curse"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -76,27 +76,19 @@
 		if(!istype(HU.head, /obj/item/clothing/head/roguetown/crown/serpcrown))
 			continue
 		
-		//Abdicate previous King
+		//Abdicate previous King, pretty slop code
 		for(var/mob/living/carbon/human/HL in GLOB.human_list)
 			if(HL.mind)
-				if(HL.mind.assigned_role == "King")
-					switch(HL.gender)
-						if("male")
-							HL.mind.assigned_role = "King Emeritus"
-						if("female")
-							HL.mind.assigned_role = "Queen Emeritus"
+				if(HL.mind.assigned_role == "King" || HL.mind.assigned_role == "Queen Consort")
+					HL.mind.assigned_role = "Towner"
 			if(HL.job == "King")
 				switch(HL.gender)
 					if("male")
-						HL.mind.assigned_role = "King Emeritus"
+						HL.job.title = "King Emeritus"
 					if("female")
-						HL.mind.assigned_role = "Queen Emeritus"
-				HL.job = "King Emeritus"
-			if(HL.mind)
-				if(HL.mind.assigned_role == "Queen Consort")
-					HL.mind.assigned_role = "Queen Dowager"
+						HL.job.title = "Queen Emeritus"
 			if(HL.job == "Queen Consort")
-				HL.job = "Queen Dowager"
+				HL.job.title = "Queen Dowager"
 
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "King"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -76,11 +76,12 @@
 		if(!istype(HU.head, /obj/item/clothing/head/roguetown/crown/serpcrown))
 			continue
 		
-		//Abdicate previous King, pretty slop code
+		//Abdicate previous King
 		for(var/mob/living/carbon/human/HL in GLOB.human_list)
 			if(HL.mind)
 				if(HL.mind.assigned_role == "King" || HL.mind.assigned_role == "Queen Consort")
-					HL.mind.assigned_role = "Towner"
+					HL.mind.assigned_role = "Towner" //So they don't get the innate traits of the king
+			//would be better to change their title directly, but that's not possible since the title comes from the job datum
 			if(HL.job == "King")
 				HL.job = "King Emeritus"
 			if(HL.job == "Queen Consort")

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -101,6 +101,11 @@
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "King"
 		HU.job = "King"
+		switch(HL.gender)
+			if("male")
+				SSticker.rulertype = "King"
+			if("female")
+				SSticker.rulertype = "Queen"
 		SSticker.rulermob = HU
 		var/dispjob = mind.assigned_role
 		GLOB.badomens -= "nolord"

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -22,6 +22,16 @@
 	give_bank_account = TRUE
 	min_pq = 2
 
+/datum/job/roguetown/exlady //just used to change the ladys title
+	title = "Queen Dowager"
+	flag = ADVENTURER
+	department_flag = NOBLEMEN
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	display_order = JDO_LADY
+	give_bank_account = TRUE
+
 /datum/outfit/job/roguetown/lady/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	ADD_TRAIT(H, RTRAIT_SEEPRICES, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -1,5 +1,5 @@
 /datum/job/roguetown/lady
-	title = "Queen"
+	title = "Queen Consort"
 	flag = LADY
 	department_flag = NOBLEMEN
 	faction = "Station"
@@ -30,32 +30,7 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	belt = /obj/item/storage/belt/rogue/leather/cloth/lady
 	armor = /obj/item/clothing/suit/roguetown/armor/armordress
-	if(SSticker.rulertype == "Queen")
-		head = /obj/item/clothing/head/roguetown/crown/serpcrown
-		cloak = /obj/item/clothing/cloak/lordcloak
-		belt = /obj/item/storage/belt/rogue/leather/plaquegold
-		armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
-		l_hand = /obj/item/rogueweapon/lordscepter
-		if(H.mind)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/bog)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/guard)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
-			if(H.age == AGE_OLD)
-				H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-			H.change_stat("intelligence", 3)
-			H.change_stat("endurance", 3)
-			H.change_stat("speed", 2)
-			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
-	else
-		head = /obj/item/clothing/head/roguetown/hennin
+	head = /obj/item/clothing/head/roguetown/hennin
 //		SSticker.rulermob = H
 	if(prob(66))
 		armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
@@ -66,11 +41,3 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
-
-/datum/job/roguetown/lady/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(SSticker.rulertype == "Queen")
-		SSticker.select_ruler()
-		if(L)
-			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is Queen of Rockhill.</span></span></b>")
-			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -22,7 +22,6 @@
 	..()
 	if(L)
 		SSticker.select_ruler()
-		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is King of Rockhill.</span></span></b>")
 		if(SSticker.rulertype == "King")
 			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is King of Rockhill.</span></span></b>")
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -1,5 +1,6 @@
 /datum/job/roguetown/lord
 	title = "King"
+	f_title = "Queen"
 	flag = LORD
 	department_flag = NOBLEMEN
 	faction = "Station"
@@ -22,22 +23,28 @@
 	if(L)
 		SSticker.select_ruler()
 		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is King of Rockhill.</span></span></b>")
-		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
+		if(SSticker.rulertype == "King")
+			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is King of Rockhill.</span></span></b>")
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
+		else
+			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is Queen of Rockhill.</span></span></b>")
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
+	head = /obj/item/clothing/head/roguetown/crown/serpcrown
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	cloak = /obj/item/clothing/cloak/lordcloak
+	belt = /obj/item/storage/belt/rogue/leather/plaquegold
+	l_hand = /obj/item/rogueweapon/lordscepter
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	id = /obj/item/clothing/ring/active/nomag	
 	if(H.gender == MALE)
-		head = /obj/item/clothing/head/roguetown/crown/serpcrown
 		pants = /obj/item/clothing/under/roguetown/tights/black
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-		cloak = /obj/item/clothing/cloak/lordcloak
-		shoes = /obj/item/clothing/shoes/roguetown/boots
-		belt = /obj/item/storage/belt/rogue/leather/plaquegold
-		backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-		id = /obj/item/clothing/ring/active/nomag
-		l_hand = /obj/item/rogueweapon/lordscepter
+		shoes = /obj/item/clothing/shoes/roguetown/boots	
 		if(H.mind)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/bog)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/guard)
@@ -72,6 +79,28 @@
 			if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch/left))
 				qdel(H.wear_mask)
 				mask = /obj/item/clothing/mask/rogue/lordmask/l
+	else //Queen
+		armor = /obj/item/clothing/suit/roguetown/armor/armordress
+		belt = /obj/item/storage/belt/rogue/leather/plaquegold
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		if(H.mind)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/bog)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/guard)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+			if(H.age == AGE_OLD)
+				H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			H.change_stat("intelligence", 3)
+			H.change_stat("endurance", 3)
+			H.change_stat("speed", 2)
+			H.change_stat("perception", 2)
+			H.change_stat("fortune", 5)
 
 	ADD_TRAIT(H, RTRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, RTRAIT_NOSEGRAB, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -18,6 +18,17 @@
 	give_bank_account = 1000
 	required = TRUE
 
+/datum/job/roguetown/exlord //just used to change the lords title
+	title = "King Emeritus"
+	f_title = "Queen Emeritus"
+	flag = ADVENTURER
+	department_flag = NOBLEMEN
+	faction = "Station"
+	total_positions = 0
+	spawn_positions = 0
+	display_order = JDO_LADY
+	give_bank_account = TRUE
+
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
 	if(L)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -89,7 +89,7 @@
 			if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch/left))
 				qdel(H.wear_mask)
 				mask = /obj/item/clothing/mask/rogue/lordmask/l
-	else //Queen
+	else //Queen, doesn't do anything at the moment as Lord is male-only
 		armor = /obj/item/clothing/suit/roguetown/armor/armordress
 		belt = /obj/item/storage/belt/rogue/leather/plaquegold
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 
 GLOBAL_LIST_INIT(noble_positions, list(
 	"King",
-	"Queen",
+	"Queen Consort",
 	"Prince",
 	"Sheriff",
 	"Bailiff",

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -87,7 +87,7 @@
 			if(get_triumphs() > 0)
 				adjust_triumphs(-1)
 
-		if(job == "King" || job == "Queen")
+		if(job == "King")
 			for(var/mob/living/carbon/human/HU in GLOB.player_list)
 				if(!HU.stat)
 					if(is_in_roguetown(HU))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This is mostly just a bug fix, before coronating a new king assigned king the ex-king role which literally doesnt exist and broke the game and made the ex-king runtime everything. So I added an actual ex-king role.

It also changes a few names to sound cooler
* changing the name of roundstart Queen to be more Queen Consort, which is more accurate as she's not a ruling queen, just married to the king.
* an abdicated king is called an King Emeritus instead of Ex-King
* the queen consort of an abdicated king is called a Queen Dowager

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the queen name bothered me also coronating people shouldn't break the game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
