### PR TITLE
Examining adventurers no longer tells you their class

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -52,9 +52,8 @@
 			var/used_title = J.title
 			if(gender == FEMALE && J.f_title)
 				used_title = J.f_title
-			if(J.wanderer_examine && J.advjob_examine)
-				used_title = advjob
-				. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the wandering [race_name] [used_title].")
+			if(J.wanderer_examine)
+				. = list("<span class='info'>ø ------------ ø\nThis is <EM>[used_name]</EM>, the wandering [race_name].")
 			else
 				if(J.advjob_examine)
 					used_title = advjob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

now it just says "This is [name], the wandering [race]."

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it's dumb to tell people's class
now rogues can disguise themselves easier

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
