### PR TITLE
Adds option to change FPS

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -196,6 +196,17 @@ Hotkey-Mode: (hotkey-mode must be on)
 	set name = "Commend Someone"
 	commendsomeone()
 
+/client/verb/changefps()
+	set category = "Options"
+	set name = "ChangeFPS"
+	if(!prefs)
+		return
+	var/newfps = input(usr, "Enter new FPS", "New FPS", 100) as null|num
+	if (!isnull(newfps))
+		prefs.clientfps = clamp(newfps, 1, 1000)
+		fps = prefs.clientfps
+		prefs.save_preferences()
+
 /*
 /client/verb/set_blur()
 	set name = "AAOn"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a verb to change your client FPS in the options tab.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's no way to change your FPS right now.  #524 set the default to 100, however if you connected to the server before this pr was merged your FPS was set and saved to the previous default of 20 and you were stuck with it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
