### PR TITLE
adventurer active player cap 75->40

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 75
-	spawn_positions = 75
+	total_positions = 40
+	spawn_positions = 40
 	allowed_races = list(
 		"Humen",
 		"Elf",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Half measure to fix people killing themselves roundstart for a new adventurer reroll, as well as preventing the adventurer overpopulation from getting any worse.

## Why It's Good For The Game

People cant behave, and it's so widespread admins cant fix the genuinely hundreds of cases every day.

Currently averaging over half the active in-game players as adventurers, which devalues adventurers to the point of suiciding to get a reroll, and makes town roles that arent in the castle nearly entirely abandoned outside of max pop.