### PR TITLE
Whip balance changes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -142,7 +142,7 @@
 	force = 23
 	name = "Repenta En"
 	desc = "An extremely well maintained whip, with a polished steel tip and gilded handle"
-	minstr = 11
+	minstr = 7
 	icon_state = "gwhip"
 
 

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -100,7 +100,7 @@
 /datum/crafting_recipe/roguetown/leather/whip
 	name = "leather whip"
 	result = /obj/item/rogueweapon/whip/antique
-	reqs = list(/obj/item/natural/hide = 2)
+	reqs = list(/obj/item/natural/hide = 2,/obj/item/natural/stone = 1)
 
 /obj/item/clothing/cloak/raincloak/brown
 	sellprice = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> Whips are only craftable by skincrafters, which is mostly adventurers and pilgrims, specifically Hunters and rangers, and these two almost never have enough strength to actually use the whip. Also makes it so the whip needs a stone to craft, since the description says it needs a stone (repenta en should need to be forged but i dunno how to do that)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. --> Allows whip to be used by the people who craft it, also i never see it used since most don't know it exists, hopefully now that it can actually be used by skincrafters it will be made and get spread around after they die.
