### PR TITLE
Misogyny lore v2

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -66,7 +66,7 @@
 	var/list/roundstart_experience
 
 	//allowed sex/race for picking
-	var/list/allowed_sexes = list(MALE,FEMALE)
+	var/list/allowed_sexes
 	var/list/allowed_races
 	var/list/allowed_patrons
 	var/list/allowed_ages = ADULT_AGES_LIST

--- a/code/modules/jobs/job_types/roguetown/church/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/confessor.dm
@@ -6,7 +6,7 @@
 	total_positions = 0
 	spawn_positions = 0
 
-	allowed_sexes = list("male")
+	allowed_sexes = list(MALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/church/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/confessor.dm
@@ -12,7 +12,7 @@
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
-		"Aasimar"
+		"Aasimar",
 	)
 	allowed_patrons = ALL_CLERIC_PATRONS
 	tutorial = "Confessors are shady agents of the church hired to spy on the populace and keep them moral. As the most fanatical members of the clergy, their main concern is assisting the local Puritan with their work in extracting confessions of sin as well as hunting night beasts and cultists that hide in plain sight."

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -6,6 +6,7 @@
 	total_positions = 3
 	spawn_positions = 4
 
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -1,14 +1,17 @@
 
 /datum/job/roguetown/priest
 	title = "Priest"
-	f_title = "Priestess"
 	flag = PRIEST
 	department_flag = CHURCHMEN
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = JCOLOR_CHURCH
-	allowed_races = list("Humen", "Aasimar")
+	allowed_sexes = list(MALE)
+	allowed_races = list(
+		"Humen", 
+		"Aasimar",
+	)
 	allowed_patrons = list(/datum/patron/divine/astrata)
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals and you will preach their wisdom to any who still heed their will. The faithless are growing in number, it is up to you to shepard them to a Gods-fearing future."
 	whitelist_req = FALSE

--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -9,7 +9,7 @@
 	allowed_sexes = list(MALE)
 	allowed_races = list(
 		"Humen",
-		"Aasimar"
+		"Aasimar",
 	)
 	allowed_patrons = list(/datum/patron/old_god)
 

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -12,7 +12,7 @@
 		"Dwarf",
 		"Aasimar",
 		"Half-Elf",
-		"Half Orc"
+		"Half Orc",
 	)
 	allowed_patrons = ALL_CLERIC_PATRONS
 	outfit = /datum/outfit/job/roguetown/templar

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -5,7 +5,7 @@
 	department_flag = CHURCHMEN
 	faction = "Station"
 	tutorial = "Templars are warriors who have forsaken wealth and title in lieu of service to the church, due to either zealotry or a past shame. They guard the church and its priest, while keeping a watchful eye against heresy and nite-creechers. Within troubled dreams, they wonder if the blood they shed makes them holy or stained."
-	allowed_sexes = list("male")
+	allowed_sexes = list(MALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -11,8 +11,9 @@
 		"Dwarf",
 		"Tiefling",
 		"Argonian",
-		"Dark Elf"
-	)
+		"Dark Elf",
+		"Half Orc",
+	) //"evil" races only
 	allowed_sexes = list(MALE, FEMALE) //only allows females because muh dark elves
 
 	display_order = JDO_DUNGEONEER

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -13,7 +13,7 @@
 		"Argonian",
 		"Dark Elf"
 	)
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE, FEMALE) //only allows females because muh dark elves
 
 	display_order = JDO_DUNGEONEER
 

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list("Humen")
 	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
 	display_order = JDO_GATEMASTER

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	allowed_races = list("Humen")
 	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
 	display_order = JDO_GATEMASTER

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	allowed_sexes = list("male", "female")
+	allowed_sexes = list(MALE)
 	allowed_races = list("Humen")
 	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
 	display_order = JDO_GATEMASTER

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -6,7 +6,7 @@
 	total_positions = 8
 	spawn_positions = 8
 
-	allowed_sexes = list("male", "female")
+	allowed_sexes = list(MALE)
 	allowed_races = list("Humen")
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the Royal Family and their Court, trained regularly in combat and siege warfare you stand a small chance of surviving the King's reign."

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -6,7 +6,7 @@
 	total_positions = 8
 	spawn_positions = 8
 
-	allowed_sexes = list(MALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list("Humen")
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the Royal Family and their Court, trained regularly in combat and siege warfare you stand a small chance of surviving the King's reign."

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -6,7 +6,7 @@
 	total_positions = 8
 	spawn_positions = 8
 
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	allowed_races = list("Humen")
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the Royal Family and their Court, trained regularly in combat and siege warfare you stand a small chance of surviving the King's reign."

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -6,14 +6,14 @@
 	total_positions = 10
 	spawn_positions = 10
 	selection_color = JCOLOR_SOLDIER
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
 		"Aasimar",
-		"Half Orc"
+		"Half Orc",
 	)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Responsible for the safety of the town and the enforcement of the King's law, you are the vanguard of the city faced with punishing those who defy his Royal Majesty. Though you've many lords to obey, as both the Church and the Sheriff have great sway over your life."

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -6,13 +6,14 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(MALE, FEMALE) //same as town guard
+	allowed_sexes = list(MALE) //same as town guard
 	allowed_races = list(
 		"Humen",
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
-		"Aasimar"
+		"Aasimar",
+		"Half Orc",
 	) //same as town guard
 	tutorial = "You've served the garrison your whole life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade..."
 	allowed_ages = list(AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE, FEMALE) //same as town guard
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -14,7 +14,7 @@
 		"Dwarf",
 		"Aasimar"
 	) //same as town guard
-	tutorial = "You've known combat your entire life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade..."
+	tutorial = "You've served the garrison your whole life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade..."
 	allowed_ages = list(AGE_OLD)
 	display_order = JDO_VET
 	whitelist_req = TRUE

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -19,7 +19,7 @@
 		"Half Orc"
 	)
 	allowed_ages = list(AGE_OLD)
-	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Guards wish it were the case."
+	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Bog Guards wish it were the case."
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -16,7 +16,7 @@
 		"Argonian",
 		"Dark Elf",
 		"Aasimar",
-		"Half Orc"
+		"Half Orc",
 	) //same as bog guard
 	allowed_ages = list(AGE_OLD)
 	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years spent in the bog guard. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Bog Guards wish it were the case."

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE, FEMALE) //same as bog guard
 	allowed_races = list(
 		"Humen",
 		"Elf",
@@ -17,9 +17,9 @@
 		"Dark Elf",
 		"Aasimar",
 		"Half Orc"
-	)
+	) //same as bog guard
 	allowed_ages = list(AGE_OLD)
-	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Bog Guards wish it were the case."
+	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years spent in the bog guard. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Bog Guards wish it were the case."
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF

--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -1,7 +1,7 @@
 /datum/job/roguetown/mercenary/desert_rider
 	title = "Desert Rider Mercenary"
 	flag = DESERT_RIDER
-	allowed_sexes = list("male", "female")
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list(
 		"Humen", 
 		"Half-Elf", 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
@@ -2,7 +2,7 @@
 	title = "Grenzelhoft Mercenary"
 	flag = GRENZELHOFT
 	tutorial = "Experts, Professionals, Expensive. Those are the first words that come to mind when the emperiate Grenzelhoft mercenary guild is mentioned. While you may work for coin like any common sellsword, mantaining the prestige of the guild will be of utmost priority."
-	allowed_sexes = list("male", "female")
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list("Humen", "Aasimar", "Half-Elf")
 	outfit = /datum/outfit/job/roguetown/mercenary/grenzelhoft
 	display_order = JDO_GRENZELHOFT

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	allowed_races = list("Humen")
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	display_order = JDO_BAILIFF
 	tutorial = "You judge the common folk and their wrongdoings if necessary. You help plan with the Councillors and maybe the King on any new issues, laws, judgings, and construction that are required to adapt to the world. You serve on a lesser level then the Sheriff,  you are from petty nobility unlike the noble Sheriff. You have two assistant Councillors that may serve as jurors to assist you in your job. You are required to enforce taxes for the King, judge people, make sure the town and manor are not in decay, and to help plan or construct new buildings. You are allowed some limited control over Guards, however it is not the focus of your job unless special circumstances are to change this."
 	whitelist_req = FALSE

--- a/code/modules/jobs/job_types/roguetown/nobility/sheriff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/sheriff.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 
 	allowed_races = list("Humen")
-	allowed_sexes = list(MALE, FEMALE)
+	allowed_sexes = list(MALE)
 	display_order = JDO_SHERIFF
 	tutorial = "Law and Order, your divine reason for existence. These animals are undeserving of your protection, for it is their sons and daughters roving the countryside with blade in hand; how many men have you lost this week just to the horrors in the woods alone? Are you the one to stand between this town and chaos, or will you fail it like they expect you to?"
 	whitelist_req = FALSE

--- a/code/modules/jobs/job_types/roguetown/other/deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/other/deathknight.dm
@@ -8,8 +8,6 @@
 	min_pq = null //no pq
 	max_pq = null
 
-	allowed_sexes = list("male", "female")
-	allowed_races = list("Humen","Humen", "Half-Elf","Dark Elf","Elf","Elf", "Dwarf","Dwarf")
 	tutorial = ""
 
 	outfit = /datum/outfit/job/roguetown/deathknight

--- a/code/modules/jobs/job_types/roguetown/other/skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/skeleton.dm
@@ -8,8 +8,6 @@
 	min_pq = null //no pq
 	max_pq = null
 
-	allowed_sexes = list("male", "female")
-	allowed_races = list("Humen","Humen", "Half-Elf","Dark Elf","Elf","Elf", "Dwarf","Dwarf")
 	tutorial = ""
 
 	outfit = /datum/outfit/job/roguetown/skeleton

--- a/code/modules/jobs/job_types/roguetown/other/tester.dm
+++ b/code/modules/jobs/job_types/roguetown/other/tester.dm
@@ -12,17 +12,7 @@
 #endif
 	min_pq = null //no pq
 	max_pq = null
-	allowed_sexes = list("male", "female")
-	allowed_races = list("Humen",
-	"Humen",
-	"Elf",
-	"Elf",
-	"Half-Elf",
-	"Dark Elf",
-	"Tiefling",
-	"Dwarf",
-	"Dwarf"
-	)
+
 	tutorial = ""
 	outfit = /datum/outfit/job/roguetown/tester
 	plevel_req = 0

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -17,10 +17,10 @@
 		"Dark Elf",
 		"Aasimar"
 	)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 
 	tutorial = "Nobody would envy your lot in life, for the role of the bathwench is not something so idly taken. It comes from a place of desperation, least usually: for any with true compassion or skill would seek position with a nunnery or the medical trade. Launder clothes and soothe wounds, that is your loathsome creed."
 
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	outfit = /datum/outfit/job/roguetown/nightmaiden
 	display_order = JDO_NIGHTMAIDEN
 	give_bank_account = TRUE

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -6,7 +6,7 @@
 	total_positions = 0 // Disabled due to ERP removal, originally 2
 	spawn_positions = 0 // Disabled due to ERP removal, originally 3
 
-	allowed_sexes = list("female")
+	allowed_sexes = list(FEMALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
@@ -17,7 +17,7 @@
 		"Aasimar",
 		"Half Orc"
 	)
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	allowed_ages = ADULT_AGES_LIST
 	outfit = /datum/outfit/job/roguetown/vagrant
 	bypass_lastclass = TRUE
 	bypass_jobban = FALSE

--- a/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
@@ -17,9 +17,9 @@
 		"Aasimar",
 		"Half Orc"
 	)
+	allowed_ages = ADULT_AGES_LIST
+	
 	tutorial = "Some say you're a strange individual, some say you're a cheat, while some claim you're a savant in the art of sausage making. Without your skilled hands and knifework, most of the livestock around the town would be wasted. "
-
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 
 	outfit = /datum/outfit/job/roguetown/beastmaster
 	display_order = JDO_BUTCHER

--- a/code/modules/jobs/job_types/roguetown/peasants/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butler.dm
@@ -14,7 +14,7 @@
 		"Dwarf",
 		"Aasimar"
 	)
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	allowed_ages = ADULT_AGES_LIST
 
 	tutorial = "Servitude unto death; your blade a charcuterie of artisanal cheeses and meat, your armor wit and classical training. You don't consider yourself a servant anymore, if anything, you're a part of the family now. You alone have raised Kings, Queens, Princesses and Princes; without you, the royals would have all starved to death."
 

--- a/code/modules/jobs/job_types/roguetown/peasants/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/jester.dm
@@ -19,7 +19,7 @@
 
 	tutorial = "The Grenzelhofts were known for their Jesters, wisemen with a tongue just as sharp as their wit. You command a position of a fool, envious of the position your superiors have upon you. Your cheap tricks and illusions of intelligence will only work for so long, and someday youll find yourself at the end of something sharper than you."
 
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	allowed_ages = ADULT_AGES_LIST
 	spells = list(/obj/effect/proc_holder/spell/self/telljoke,/obj/effect/proc_holder/spell/self/telltragedy)
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -6,7 +6,7 @@
 	total_positions = 0
 	spawn_positions = 0
 
-	allowed_sexes = list("male")
+	allowed_sexes = list(MALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -21,7 +21,7 @@
 
 	tutorial = "The Nightmaster is technically a noble. Owner of the Whitevein Lounge, a decaying bathhouse converted into a den of low-lifes. A troublemaking rake that the others hate to tolerate."
 
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	allowed_ages = ADULT_AGES_LIST
 	outfit = /datum/outfit/job/roguetown/nightman
 	display_order = JDO_NIGHTMAN
 	give_bank_account = TRUE

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 5
 	display_order = JDO_SOILSON
 	selection_color = JCOLOR_PEASANT
-	allowed_sexes = list("male", "female")
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = list(
 		"Humen",
 		"Elf",

--- a/code/modules/jobs/job_types/roguetown/serfs/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/serfs/archivist.dm
@@ -14,7 +14,7 @@
 		"Aasimar"
 	)
 	allowed_patrons = list(/datum/patron/divine/noc)
-	allowed_ages = list(AGE_OLD, AGE_MIDDLEAGED)
+	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 
 	outfit = /datum/outfit/job/roguetown/archivist
 	display_order = 19

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -7,10 +7,9 @@
 	spawn_positions = 2
 	allowed_races = list(
 		"Humen",
-		"Elf",
-		"Half-Elf"
-	) //same shit as town guard
-	allowed_sexes = list(MALE)
+		"Half-Elf",
+	) //should be humen only just like knight, but we give leeway to half elves because maybe a knight banged an elf
+	allowed_sexes = list(MALE) //same as knight
 	allowed_ages = YOUNG_AGES_LIST
 
 	tutorial = "Mom 'n' Da said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. "

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -424,7 +424,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		return JOB_UNAVAILABLE_GENERIC
 	if(!isnull(job.max_pq) && (get_playerquality(ckey) > job.max_pq))
 		return JOB_UNAVAILABLE_GENERIC
-	if(!(client.prefs.gender in job.allowed_sexes))
+	if(length(job.allowed_sexes) && !(client.prefs.gender in job.allowed_sexes))
 		return JOB_UNAVAILABLE_RACE
 	if(length(job.allowed_ages) && !(client.prefs.age in job.allowed_ages))
 		return JOB_UNAVAILABLE_RACE


### PR DESCRIPTION
## About The Pull Request

Females are barred from the following roles which they previously could play for some reason:
-Sheriff
-Bailiff
-Gatemaster
-Castle guard
-Town guard
-Veteran

Does several code improvements such as using gender string defines on allowed_sexes.

## Why It's Good For The Game

This server is dark fantasy and racism and misogyny are both integral to the setting Zeth tried to build. 
Straying from either of these means straying from the soul of the server, which is something I am not comfortable with by any means. I have no idea how these roles ended up being able to be played by both genders, as it sincerely does not align with the previous vision, or my own one, for the setting.
