### PR TITLE
Argonian flavor

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -19,6 +19,7 @@
 #define RTRAIT_NUDIST					"Nudist" //you can't wear most clothes
 #define RTRAIT_RETARD_ANATOMY			"Inhumen Anatomy" //can't wear hats and shoes
 #define RTRAIT_NASTY_EATER 				"Inhumen Digestion" //can drink murky water and eat organs
+#define RTRAIT_RAPID_REGENERATION		"Rapid Regeneration"
 
 #define TRAIT_SPELLCOCKBLOCK "spellcockblock" //prevents spellcasting
 #define TRAIT_NOSLEEP				"Fatal Insomnia"
@@ -58,6 +59,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ANTIMAGIC = "I am immune to most forms of magic.",
 	TRAIT_SHOCKIMMUNE = "I am immune to electrical shocks.",
 	TRAIT_NOSLEEP = "<span class='warning'>I can't sleep.</span>",
+	RTRAIT_RAPID_REGENERATION = "I can slowly heal my wounds at the cost of extreme nutritional-intake requirements.",
 ))
 
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -19,7 +19,7 @@
 #define RTRAIT_NUDIST					"Nudist" //you can't wear most clothes
 #define RTRAIT_RETARD_ANATOMY			"Inhumen Anatomy" //can't wear hats and shoes
 #define RTRAIT_NASTY_EATER 				"Inhumen Digestion" //can drink murky water and eat organs
-#define RTRAIT_RAPID_REGENERATION		"Rapid Regeneration"
+#define RTRAIT_RAPID_REGENERATION		"Inhumen Regeneration" //self heals, needs constant food intake, lack of food slowly die of oxygen loss.
 
 #define TRAIT_SPELLCOCKBLOCK "spellcockblock" //prevents spellcasting
 #define TRAIT_NOSLEEP				"Fatal Insomnia"
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ANTIMAGIC = "I am immune to most forms of magic.",
 	TRAIT_SHOCKIMMUNE = "I am immune to electrical shocks.",
 	TRAIT_NOSLEEP = "<span class='warning'>I can't sleep.</span>",
-	RTRAIT_RAPID_REGENERATION = "I can slowly heal my wounds at the cost of extreme nutritional-intake requirements.",
+	RTRAIT_RAPID_REGENERATION = "My wounds slowly heal at the cost of extreme nutritional-intake requirements.",
 ))
 
 

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -79,7 +79,7 @@
 	duration = 1
 
 /datum/status_effect/debuff/uncookedfood/on_apply()
-	if(iscarbon(owner))
+	if(iscarbon(owner) && !HAS_TRAIT(owner, RTRAIT_NASTY_EATER))
 		var/mob/living/carbon/C = owner
 		C.add_nausea(100)
 	return ..()
@@ -100,7 +100,7 @@
 
 /datum/status_effect/debuff/burnedfood/on_apply()
 	owner.add_stress(/datum/stressevent/burntmeal)
-	if(iscarbon(owner))
+	if(iscarbon(owner) && !HAS_TRAIT(owner, RTRAIT_NASTY_EATER))
 		var/mob/living/carbon/C = owner
 		C.add_nausea(100)
 	return ..()
@@ -112,7 +112,7 @@
 
 /datum/status_effect/debuff/rotfood/on_apply()
 	owner.add_stress(/datum/stressevent/rotfood)
-	if(iscarbon(owner))
+	if(iscarbon(owner) && !HAS_TRAIT(owner, RTRAIT_NASTY_EATER))
 		var/mob/living/carbon/C = owner
 		C.add_nausea(200)
 	return ..()

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -50,6 +50,46 @@
 			C.adjustBruteLoss(-0.8, FALSE)
 			C.adjustFireLoss(-0.4, FALSE)
 
+/datum/quirk/rapidregen
+	name = "Rapid Regeneration"
+	desc = ""
+	value = 2
+	mob_trait = RTRAIT_RAPID_REGENERATION
+	gain_text = "<span class='notice'>I feel like my wounds heal faster.</span>"
+	lose_text = "<span class='danger'>I no longer feel like I can self-heal efficiently.</span>"
+	
+
+/datum/quirk/rapidregen/on_process()
+// BODY_ZONE_L_ARM,BODY_ZONE_R_ARM,BODY_ZONE_HEAD,BODY_ZONE_CHEST,BODY_ZONE_L_LEG,BODY_ZONE_R_LEG
+	var/mob/living/carbon/C = quirk_holder
+//	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_HEAD)
+	switch(C.nutrition)
+		if (350 to 1000)
+			C.adjustBruteLoss(-0.5, TRUE)
+			C.adjustFireLoss(-0.5, TRUE)
+			C.adjust_nutrition(-2, TRUE)
+			C.get_bodypart(BODY_ZONE_HEAD).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_HEAD).heal_wounds(5, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_L_ARM).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_L_ARM).heal_wounds(5, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_R_ARM).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_R_ARM).heal_wounds(5, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_CHEST).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_CHEST).heal_wounds(5, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_L_LEG).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_L_LEG).heal_wounds(5, null, BODYPART_ORGANIC)	
+			C.get_bodypart(BODY_ZONE_R_LEG).heal_damage(1, null, BODYPART_ORGANIC)
+			C.get_bodypart(BODY_ZONE_R_LEG).heal_wounds(5, null, BODYPART_ORGANIC)			
+			C.update_damage_overlays()
+		if (345 to 349)
+			to_chat(C, "I am wasting away. I desperately need to eat something or someone!")
+			C.adjust_nutrition(-2, TRUE)
+		if (250 to 344)
+			C.adjust_nutrition(-2, TRUE)
+		if (0 to 249)
+			C.adjust_nutrition(-0.05, TRUE)
+			C.adjustOxyLoss(2, TRUE)
+
 /datum/quirk/empath
 	name = "Empath"
 	desc = ""

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -82,7 +82,7 @@
 			C.get_bodypart(BODY_ZONE_R_LEG).heal_wounds(5, null, BODYPART_ORGANIC)			
 			C.update_damage_overlays()
 		if (345 to 349)
-			to_chat(C, "I am wasting away. I desperately need to eat something or someone!")
+			to_chat(C, "I am wasting away! I desperately need to eat something or someone!")
 			C.adjust_nutrition(-2, TRUE)
 		if (250 to 344)
 			C.adjust_nutrition(-2, TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
@@ -11,7 +11,7 @@
 	skin_tone_wording = "Bog"
 
 	species_traits = list(EYECOLOR,LIPS)
-	inherent_traits = list(TRAIT_NOMOBSWAP,RTRAIT_RETARD_ANATOMY,RTRAIT_NASTY_EATER)
+	inherent_traits = list(TRAIT_NOMOBSWAP,RTRAIT_RETARD_ANATOMY,RTRAIT_NASTY_EATER,RTRAIT_RAPID_REGENERATION)
 	use_skintones = TRUE
 	disliked_food = NONE
 	liked_food = NONE
@@ -52,10 +52,12 @@
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 	C.grant_language(/datum/language/common)
+	C.add_quirk(/datum/quirk/rapidregen)
 
 /datum/species/lizard/brazil/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
+	C.remove_quirk(/datum/quirk/rapidregen)
 
 /datum/species/lizard/brazil/qualifies_for_rank(rank, list/features)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adjusts nastyeater trait to allow eating of uncooked, burned and rotten food (including organs). Gives the argonian a wound healing quirk in exchange for higher metabolism (greater nutrition loss). Starvation results in a slow death from oxygen loss. The lizard still suffers from blood loss as a weakness and would have to rest/drink water to regain.
Caution: code is very slopp

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hopefully pushes argonian to be a minor admin converted antag role that may have to resort to the new feature of butchering peoples head to eat.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

https://discord.com/channels/1209810478612873256/1225593857325142117/1240061453122277516