### PR TITLE
Updates say.dm regex to cover more OOC symbols.

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		SSblackbox.record_feedback("tally", "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return
 	
-	var/static/regex/ooc_regex = regex(@"^[\(\[\{\<\]\)].*|.*[\)\]\}\>\(\[\{\>]$|^[\(\[\{\<\]\)].*[\)\]\}\>\(\[\{\>]$") //Yes, i know.
+	var/static/regex/ooc_regex = regex(@"^(?=.*[\(\)\[\]\<\>\{\}]).*$") //Yes, i know.
 	if(findtext(message, ooc_regex))
 		emote("me", 1, "mumbles incoherently.")
 		to_chat(src, "<span class='warning'>That was stupid of me. I should meditate on my actions.</span>")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		SSblackbox.record_feedback("tally", "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return
 	
-	var/static/regex/ooc_regex = regex(@"^(?:[\(\[\{].*|.*[\)\]\}])$")
+	var/static/regex/ooc_regex = regex(@"^[\(\[\{\<\]\)].*|.*[\)\]\}\>\(\[\{\>]$|^[\(\[\{\<\]\)].*[\)\]\}\>\(\[\{\>]$") //Yes, i know.
 	if(findtext(message, ooc_regex))
 		emote("me", 1, "mumbles incoherently.")
 		to_chat(src, "<span class='warning'>That was stupid of me. I should meditate on my actions.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The regex now detects any occurrence of the characters (, ), [, ], <, >, {, or } said by the player and flags it as LOOC.

## Why It's Good For The Game

OOC bad, old regex could be exploited.