### PR TITLE
minor skincraft and sew QoL

### DIFF
--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -8,7 +8,7 @@
 	possible_transfer_amounts = list(3,6,9)
 	volume = 64
 	dropshrink = 0.5
-	sellprice = 10
+	sellprice = 50 #only obtainable with skincrafting, and not made often
 	closed = FALSE
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK
 	obj_flags = CAN_BE_HIT

--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -8,7 +8,7 @@
 	possible_transfer_amounts = list(3,6,9)
 	volume = 64
 	dropshrink = 0.5
-	sellprice = 50 #only obtainable with skincrafting, and not made often
+	sellprice = 50 
 	closed = FALSE
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK
 	obj_flags = CAN_BE_HIT

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -79,6 +79,11 @@
 	reqs = list(/obj/item/natural/hide = 1)
 	sellprice = 26
 
+/datum/crafting_recipe/roguetown/leather/vest
+	name = "leather vest"
+	result = /obj/item/clothing/suit/roguetown/armor/leather/vest
+	reqs = list(/obj/item/natural/hide = 2)
+
 /datum/crafting_recipe/roguetown/leather/armor
 	name = "leather armor"
 	result = /obj/item/clothing/suit/roguetown/armor/leather
@@ -97,11 +102,6 @@
 	result = /obj/item/clothing/cloak/raincloak/brown
 	reqs = list(/obj/item/natural/hide = 2)
 
-/datum/crafting_recipe/roguetown/leather/whip
-	name = "leather whip"
-	result = /obj/item/rogueweapon/whip
-	reqs = list(/obj/item/natural/hide = 2,/obj/item/natural/stone = 1)
-
 /obj/item/clothing/cloak/raincloak/brown
 	sellprice = 20
 
@@ -109,7 +109,6 @@
 	name = "fur cloak"
 	result = /obj/item/clothing/cloak/raincloak/furcloak/crafted
 	reqs = list(/obj/item/natural/hide = 2,/obj/item/natural/fur = 1)
-
 
 /obj/item/clothing/cloak/raincloak/furcloak/crafted
 	sellprice = 55
@@ -119,7 +118,12 @@
 	result = /obj/item/natural/saddle
 	reqs = list(/obj/item/natural/hide = 2)
 
-/datum/crafting_recipe/roguetown/leather/vest
-	name = "leather vest"
-	result = /obj/item/clothing/suit/roguetown/armor/leather/vest
-	reqs = list(/obj/item/natural/hide = 2)
+/datum/crafting_recipe/roguetown/leather/whip
+	name = "leather whip"
+	result = /obj/item/rogueweapon/whip
+	reqs = list(/obj/item/natural/hide = 2,/obj/item/natural/stone = 1)
+
+/datum/crafting_recipe/roguetown/instrument/drum
+	name = "Drum"
+	result = /obj/item/rogue/instrument/drum
+	reqs = list(/obj/item/natural/hide = 1,/obj/item/grown/log/tree/small = 1)

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -123,7 +123,7 @@
 	result = /obj/item/rogueweapon/whip
 	reqs = list(/obj/item/natural/hide = 2,/obj/item/natural/stone = 1)
 
-/datum/crafting_recipe/roguetown/instrument/drum
+/datum/crafting_recipe/roguetown/leather/drum
 	name = "Drum"
 	result = /obj/item/rogue/instrument/drum
 	reqs = list(/obj/item/natural/hide = 1,/obj/item/grown/log/tree/small = 1)

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -10,9 +10,9 @@
 	reqs = list(/obj/item/natural/cloth = 1)
 	craftdiff = 0
 
-/datum/crafting_recipe/roguetown/sewing/redheadband
-	name = "red headband"
-	result = list(/obj/item/clothing/head/roguetown/headband)
+/datum/crafting_recipe/roguetown/sewing/loincloth
+	name = "loincloth"
+	result = list(/obj/item/clothing/under/roguetown/loincloth)
 	reqs = list(/obj/item/natural/cloth = 1)
 	craftdiff = 0
 
@@ -53,6 +53,13 @@
 				/obj/item/natural/fibers = 2)
 	craftdiff = 1
 
+/datum/crafting_recipe/roguetown/sewing/knitcap
+	name = "knit cap"
+	result = list(/obj/item/clothing/head/roguetown/knitcap)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/sewing/basichood
 	name = "hood"
 	result = list(/obj/item/clothing/head/roguetown/roguehood)
@@ -72,13 +79,6 @@
 /datum/crafting_recipe/roguetown/sewing/coif
 	name = "coif"
 	result = list(/obj/item/clothing/neck/roguetown/coif)
-	reqs = list(/obj/item/natural/cloth = 2,
-				/obj/item/natural/fibers = 1)
-	craftdiff = 2
-
-/datum/crafting_recipe/roguetown/sewing/knitcap
-	name = "knit cap"
-	result = list(/obj/item/clothing/head/roguetown/knitcap)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 2
@@ -112,6 +112,8 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 2
 
+/* craftdif of 3+ */
+
 /datum/crafting_recipe/roguetown/sewing/fancyhat
 	name = "fancy hat"
 	result = list(/obj/item/clothing/head/roguetown/fancyhat)
@@ -122,7 +124,7 @@
 /datum/crafting_recipe/roguetown/sewing/gambeson
 	name = "gambeson"
 	result = /obj/item/clothing/suit/roguetown/armor/gambeson
-	reqs = list(/obj/item/natural/fibers = 20)
+	reqs = list(/obj/item/natural/fibers = 18)
 	tools = list(/obj/item/needle)
 	craftdiff = 3
 
@@ -150,6 +152,6 @@
 /datum/crafting_recipe/roguetown/sewing/jupon
 	name = "jupon"
 	result = list(/obj/item/clothing/cloak/stabard/surcoat)
-	reqs = list(/obj/item/natural/cloth = 4,
+	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> Cleans up the order in skincrafting, also adds a drum for ooga booga skincrafting activities. Sewing wise, removes the red headband because it is the same as normal recipe + dying changes soon, added a loincloth in it's place (for more ooga booga activities), also changed some sewing costs, specifically gambesons to be 18 fibre rather than 20 so that 3 stacks of fibre is just enough to make it for QoL. Also makes waterskins cost a lot more since it's only obtainable through skincrafting (to my knowledge) and also because they are really useful and i have never seen one besides me making it for myself.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. --> Mainly for QoL, better order in the menu and removing redundant stuff
