### PR TITLE
Change Necra tabard to have Bone-colored cross

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/cloak/tabard/crusader/necra
 	color = "#222223"
-	detail_color = "#96998C" 
+	detail_color = "#CACBC5" 
 
 /obj/item/clothing/cloak/tabard/crusader/pestra
 	color = CLOTHING_WHITE


### PR DESCRIPTION
bone-colored cross on necra

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

changes hexcode for the necra tabard from #96998C to #CACBC5.

## Why It's Good For The Game

Gives visibility and accent. Purely aesthetic.
