### PR TITLE
Necrodus

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -13,14 +13,13 @@
 		"Dwarf",
 		"Aasimar"
 	)
-	allowed_patrons = ALL_CLERIC_PATRONS
+	allowed_patrons = list(/datum/patron/divine/astrata, /datum/patron/divine/dendor, /datum/patron/divine/pestra, /datum/patron/divine/noc)
 	outfit = /datum/outfit/job/roguetown/monk
 	tutorial = "Chores, some more chores- Even more chores.. Oh how the life of a humble cleric is exhausting… You have faith, but even you know you gave up a life of adventure for that of the security in the Church. Assist the Priest in their daily tasks, maybe today will be the day something interesting happens."
 
 	display_order = JDO_MONK
 	give_bank_account = TRUE
 	min_pq = 0
-	max_pq = null
 
 /datum/outfit/job/roguetown/monk
 	name = "Acolyte"
@@ -39,6 +38,16 @@
 			wrists = /obj/item/clothing/wrists/roguetown/wrappings
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
+		if("Dendor")
+			head = /obj/item/clothing/head/roguetown/dendormask
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+			armor = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
+		if("Pestra") //PLEASE add plague doctor gear later, this SUCKS dude
+			head = /obj/item/clothing/head/roguetown/necrahood
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
+			armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
 		if("Noc")
 			head = /obj/item/clothing/head/roguetown/roguehood/nochood
 			neck = /obj/item/clothing/neck/roguetown/psicross/noc
@@ -46,22 +55,6 @@
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/noc
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
-		if("Dendor")
-			head = /obj/item/clothing/head/roguetown/dendormask
-			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
-		if("Necra")
-			head = /obj/item/clothing/head/roguetown/necrahood
-			neck = /obj/item/clothing/neck/roguetown/psicross/necra
-			shoes = /obj/item/clothing/shoes/roguetown/boots
-			pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
-		if("Pestra") //PLEASE add plague doctor gear later, this SUCKS dude
-			head = /obj/item/clothing/head/roguetown/necrahood
-			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
-			shoes = /obj/item/clothing/shoes/roguetown/boots
-			pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
@@ -1,44 +1,42 @@
 /datum/job/roguetown/undertaker
 	title = "Gravedigger"
 	flag = GRAVEDIGGER
-	department_flag = PEASANTS
+	department_flag = CHURCHMEN
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 3
+	allowed_patrons = list(/datum/patron/divine/necra)
 
 	allowed_races = list(
 		"Humen",
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
+		"Aasimar",		
 		"Tiefling",
 		"Argonian",
 		"Dark Elf",
 		"Aasimar",
 		"Half Orc"
 	)
-	tutorial = "The dead don't speak, least if you're doing your job right. You've a pilfers dream—for few have enough to pay for your services out-of-pocket. So you take it from the fallen. Your job isnt considered highly, but without you, who else would disgrace the sanctity of the dead?"
+	tutorial = "The dead should stay dead, and they will under your watch. A life of devotion is rarely one of riches, but you turn a coin by plying your trade to the fallen. Your job isnt considered highly, but without you, who else will maintain the sanctity of death?"
 
 	outfit = /datum/outfit/job/roguetown/undertaker
 	display_order = JDO_GRAVEMAN
 	give_bank_account = TRUE
 	min_pq = -10
-	max_pq = null
 
 /datum/outfit/job/roguetown/undertaker/pre_equip(mob/living/carbon/human/H)
 	..()
-	pants = /obj/item/clothing/under/roguetown/tights/black
+	pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
 	cloak = /obj/item/clothing/cloak/raincloak/mortus
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/roguekey/graveyard
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backr = /obj/item/rogueweapon/shovel
-	if(H.gender == FEMALE)
-		pants = null
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
-	else
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+	neck = /obj/item/clothing/neck/roguetown/psicross/necra
+	armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
@@ -46,7 +44,14 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("intelligence", -2)
 		H.change_stat("speed", 1)
 	ADD_TRAIT(H, RTRAIT_NOSTINK, TRAIT_GENERIC)
+
+	var/datum/devotion/cleric_holder/C = new /datum/devotion/cleric_holder(H, H.patron)
+	C.holder_mob = H
+	C.update_devotion(50, 50)
+	C.grant_spells(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/gravedigger.dm
@@ -37,6 +37,7 @@
 	backr = /obj/item/rogueweapon/shovel
 	neck = /obj/item/clothing/neck/roguetown/psicross/necra
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
+	head = /obj/item/clothing/head/roguetown/necrahood
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)


### PR DESCRIPTION
Kicks out the Necralytes from the church because no one likes them and they're weird. 

Gravediggers have taken up the mantle due to their time spent in the graveyards performing the burial rites of the Undermaiden and a familiarity with death.

This will be a good thing, I promise.