### PR TITLE
Makes zombies have stamina again

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie.dm
@@ -26,7 +26,6 @@
 	var/last_bite
 	/// Traits applied to the owner mob when we turn into a zombie
 	var/static/list/traits_zombie = list(
-		RTRAIT_NOFATSTAM,
 		TRAIT_NOMOOD,
 		TRAIT_NOHUNGER,
 		TRAIT_EASYDISMEMBER,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

removes nostam from their traits. It's really only meant for AI.

## Why It's Good For The Game

Zombies are blatantly straight upgrades, and this makes it more uncertain. No stat changes, but at least you're on even ground in terms of stamina mechanics, which is a large part of fighting.