### PR TITLE
Quality Control MK1

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -106,8 +106,6 @@
 			spread = 150 - (150 * (user.client.chargedprog / 100))
 	else
 		spread = 0
-	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
-		var/obj/projectile/BB = CB.BB
 	cocked = FALSE
 	..()
 

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -15,7 +15,7 @@
 		"Tiefling",
 		"Dark Elf",
 		"Aasimar",
-		"Half Orc",
+		"Half Orc"
 	)
 	tutorial = "You've handed your resume, which mostly consisted of showing up, and in exchange you have a spot among the Bog Guards. You have a roof over your head, coin in your pocket, and a thankless job protecting the outskirts of town against bandits and volfs."
 	display_order = JDO_TOWNGUARD

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -12,7 +12,7 @@
 		"Tiefling",
 		"Argonian",
 		"Dark Elf",
-		"Half Orc",
+		"Half Orc"
 	) //"evil" races only
 	allowed_sexes = list(MALE, FEMALE) //only allows females because muh dark elves
 

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -12,8 +12,7 @@
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
-		"Aasimar",
-		"Half Orc",
+		"Aasimar"
 	)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	tutorial = "Responsible for the safety of the town and the enforcement of the King's law, you are the vanguard of the city faced with punishing those who defy his Royal Majesty. Though you've many lords to obey, as both the Church and the Sheriff have great sway over your life."

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -12,8 +12,7 @@
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
-		"Aasimar",
-		"Half Orc",
+		"Aasimar"
 	) //same as town guard
 	tutorial = "You've served the garrison your whole life. There isn't a way to kill a man you havent practiced in the tapestries of war itself. You wouldn't call yourself a hero, those belong to the men left rotting in the fields of where you practiced your ancient trade. You don't sleep well at night anymore, you don't like remembering what you've had to do to survive. Trading adventure for stable pay was the only logical solution, and maybe someday you'll get to lay down the blade..."
 	allowed_ages = list(AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -15,8 +15,8 @@
 		"Tiefling",
 		"Argonian",
 		"Dark Elf",
-		"Aasimar",
-		"Half Orc",
+		"Aasimar"
+
 	) //same as bog guard
 	allowed_ages = list(AGE_OLD)
 	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years spent in the bog guard. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the Bog Guards wish it were the case."

--- a/code/modules/jobs/job_types/roguetown/goblin/goblincook.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblincook.dm
@@ -3,12 +3,13 @@
 	flag = GOBLINCOOK
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	allowed_sexes = list(MALE)
 	allowed_races = list("Goblin")
 	allowed_patrons = list(/datum/patron/inhumen/graggar)
 	tutorial = "Cook, farm, butcher. Make king happy with apple pies! Don't forget about your brothers."
+
 
 	outfit = /datum/outfit/job/roguetown/goblincook
 	display_order = JDO_GOBLINCOOK

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinguard.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinguard.dm
@@ -3,8 +3,8 @@
 	flag = GOBLINGUARD
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 15
-	spawn_positions = 10
+	total_positions = 0
+	spawn_positions = 0
 	allowed_sexes = list(MALE)
 	allowed_races = list("Goblin")
 	allowed_patrons = list(/datum/patron/inhumen/graggar)

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinking.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinking.dm
@@ -4,8 +4,8 @@
 	flag = GOBLINKING
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_sexes = list(MALE)
 	allowed_races = list("Goblin")
 	allowed_patrons = list(/datum/patron/inhumen/graggar)

--- a/code/modules/jobs/job_types/roguetown/goblin/goblinsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/goblinsmith.dm
@@ -3,8 +3,8 @@
 	flag = GOBLINSMITH
 	department_flag = GOBLIN
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	allowed_sexes = list(MALE)
 	allowed_races = list("Goblin")
 	allowed_patrons = list(/datum/patron/inhumen/graggar)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -438,7 +438,6 @@ ROUNDSTART_RACES elfw
 ROUNDSTART_RACES elfd
 ROUNDSTART_RACES halforc 
 ROUNDSTART_RACES aasimar
-ROUNDSTART_RACES goblinp
 
 
 ## Races that are a meme and should not be accessible in normal gameplay, unless you are insane

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -8,7 +8,6 @@
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\blackstone.dm"
 #include "_maps\templates\bog_shack_small.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"


### PR DESCRIPTION
Formerly dead, I've been summoned to do some quality control via my discord dms.
This PR does the following:
Disables Goblin jobs/species for the moment - They are half-baked, loaded with bugs and other things that need to be addressed before they are in live play. Secondly, there are friendly goblins in the town.

Thus for goblins to go back live:
They need polished until emoney is happy with the state of them.
They need to be made antags (probably swap the 20 bandits out sometimes with 20 goblins + a kingdom for some spicy variation)
(The fact there were/still are AI goblins should have still clued you in on this as I stated before my departure)

Half-Orcs removed from most garrison jobs outside of Bog guard
Rockhill is a human town in lore, and they are a bit too inhuman looking despite being half-human/more human than some of the other things in there. (haha, small details not that you'd know much about those!)

Warning Removals:
The person who mapped in the blackstone map also left their map file ticked in instead of using the standard loading file, not that it matters but its still going to load the map anyways, thus blackstone.dm was unticked, and the rt.dm map load is used.

The person who decided to remove the (actually really shitty) perception modifier on some projectiles removed the perception conditional check that set the shit higher, but ignored the loop, resulting in a warning that it was useless. That was also removed.