### PR TITLE
Eat your eye out - Replaces most instakill crits on the head with being crippled for life

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -177,6 +177,9 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 	var/mob/living/carbon/human/H = user
 	if(!H.wear_mask)
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/rogue/eyepatch(H), SLOT_WEAR_MASK)
+	var/obj/item/organ/eyes/my_eyes = H.getorganslot(ORGAN_SLOT_EYES)
+	if(my_eyes)
+		my_eyes.right_poked = TRUE
 	H.update_fov_angles()
 
 /datum/charflaw/noeyel
@@ -190,4 +193,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 	var/mob/living/carbon/human/H = user
 	if(!H.wear_mask)
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/rogue/eyepatch/left(H), SLOT_WEAR_MASK)
+	var/obj/item/organ/eyes/my_eyes = H.getorganslot(ORGAN_SLOT_EYES)
+	if(my_eyes)
+		my_eyes.left_poked = TRUE
 	H.update_fov_angles()

--- a/code/modules/mob/vision_cone.dm
+++ b/code/modules/mob/vision_cone.dm
@@ -271,7 +271,7 @@ client/
 		if(H.wear_mask)
 			if(H.wear_mask.block2add)
 				fovangle |= H.wear_mask.block2add
-		var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
+		var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
 		if(eyes)
 			if(eyes.left_poked)
 				fovangle |= FOV_LEFT

--- a/code/modules/mob/vision_cone.dm
+++ b/code/modules/mob/vision_cone.dm
@@ -271,10 +271,12 @@ client/
 		if(H.wear_mask)
 			if(H.wear_mask.block2add)
 				fovangle |= H.wear_mask.block2add
-		if(has_flaw(/datum/charflaw/noeyer))
-			fovangle |= FOV_RIGHT
-		if(has_flaw(/datum/charflaw/noeyel))
-			fovangle |= FOV_LEFT
+		var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
+		if(eyes)
+			if(eyes.left_poked)
+				fovangle |= FOV_LEFT
+			if(eyes.right_poked)
+				fovangle |= FOV_RIGHT
 		if(H.STAPER < 5)
 			fovangle |= FOV_LEFT
 			fovangle |= FOV_RIGHT

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -43,6 +43,11 @@
 	grabtargets = list(BODY_ZONE_PRECISE_R_EYE, BODY_ZONE_PRECISE_L_EYE, BODY_ZONE_PRECISE_NOSE, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_SKULL, BODY_ZONE_PRECISE_EARS, BODY_ZONE_PRECISE_NECK)
 	resistance_flags = FLAMMABLE
 
+	/// Our left eye has been poked out, ouch
+	var/left_eye_poked = FALSE
+	/// Our right eye has been poked out, ouch
+	var/right_eye_poked = FALSE
+	/// Brainkill means that this head is considered dead and revival is impossible
 	var/brainkill = FALSE
 
 /obj/item/bodypart/head/grabbedintents(mob/living/user, precise)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -441,6 +441,7 @@
 								owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The eyes are gored!</span>"
 								my_eyes.forceMove(get_turf(owner))
 								my_eyes.Remove(owner)
+								qdel(my_eyes)
 						else
 							if(!brainkill)
 								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -442,7 +442,6 @@
 								owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The eyes are gored!</span>"
 								my_eyes.forceMove(get_turf(owner))
 								my_eyes.Remove(owner)
-								qdel(my_eyes)
 							owner.update_fov_angles()
 						else
 							if(!brainkill)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -278,7 +278,7 @@
 		if(user.goodluck(2))
 			dam += 10
 	if(bclass == BCLASS_TWIST)
-		if(zone_precise == "head")
+		if(zone_precise == BODY_ZONE_HEAD)
 			if(brute_dam < max_damage)
 				return FALSE
 			for(var/datum/wound/necksnap/S in wounds)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -196,7 +196,7 @@
 			foundy= TRUE
 		if(zone_precise == BODY_ZONE_PRECISE_STOMACH)
 			if (prob(used+10))
-				if(!can_bloody_wound())
+				if(!can_bloody_wound() || resistance)
 					return FALSE
 				var/organ_spilled = FALSE
 				var/turf/T = get_turf(owner)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -270,6 +270,9 @@
 						return TRUE
 
 /obj/item/bodypart/head/try_crit(bclass,dam,mob/living/user,zone_precise)
+	var/static/list/eyestab_zones = list(BODY_ZONE_PRECISE_R_EYE, BODY_ZONE_PRECISE_L_EYE)
+	var/static/list/tonguestab_zones = list(BODY_ZONE_PRECISE_MOUTH)
+	var/static/list/do_nothing_zones = list(BODY_ZONE_PRECISE_NOSE)
 	var/resistance = HAS_TRAIT(owner, RTRAIT_CRITICAL_RESISTANCE)
 	if(user && dam)
 		if(user.goodluck(2))
@@ -371,8 +374,44 @@
 			if(prob(used))
 				for(var/datum/wound/artery/A in wounds)
 					if(bclass == BCLASS_STAB)
-						if(!resistance)
+						if(resistance)
+							return TRUE
+						if(zone_precise in eyestab_zones)
+							var/obj/item/organ/eyes/my_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
+							if(my_eyes)
+								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+								owner.Stun(10)
+								owner.blind_eyes(10)
+								if(zone_precise == BODY_ZONE_PRECISE_R_EYE)
+									my_eyes.right_poked = TRUE
+									if(!my_eyes.left_poked)
+										owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The right eye is poked out!</span>"
+								else
+									my_eyes.left_poked = TRUE
+									if(!my_eyes.right_poked)
+										owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The left eye is poked out!</span>"
+								if(my_eyes.right_poked && my_eyes.left_poked)
+									owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The eyes are gored!</span>"
+									my_eyes.forceMove(get_turf(owner))
+									my_eyes.Remove(owner)
+							else
+								if(!brainkill)
+									playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+								owner.death()
+								brainkill = TRUE
+						else if(zone_precise in tonguestab_zones)
+							var/obj/item/organ/tongue/tongue_up_my_asshole = owner.getorganslot(ORGAN_SLOT_TONGUE)
+							if(tongue_up_my_asshole)
+								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+								owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The tongue flies off in an arc!</span>"
+								owner.Stun(10)
+								tongue_up_my_asshole.forceMove(get_turf(owner))
+								tongue_up_my_asshole.Remove(owner)
+						else if(!(zone_precise in do_nothing_zones))
+							if(!brainkill)
+								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
 							owner.death()
+							brainkill = TRUE
 						return TRUE
 					return FALSE
 				playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
@@ -382,7 +421,42 @@
 				owner.Slowdown(20)
 				shake_camera(owner, 2, 2)
 				if(bclass == BCLASS_STAB)
-					if(!resistance)
+					if(resistance)
+						return TRUE
+					if(zone_precise in eyestab_zones)
+						var/obj/item/organ/eyes/my_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
+						if(my_eyes)
+							playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+							owner.Stun(10)
+							owner.blind_eyes(10)
+							if(zone_precise == BODY_ZONE_PRECISE_R_EYE)
+								my_eyes.right_poked = TRUE
+								if(!my_eyes.left_poked)
+									owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The right eye is poked out!</span>"
+							else
+								my_eyes.left_poked = TRUE
+								if(!my_eyes.right_poked)
+									owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The left eye is poked out!</span>"
+							if(my_eyes.right_poked && my_eyes.left_poked)
+								owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The eyes are gored!</span>"
+								my_eyes.forceMove(get_turf(owner))
+								my_eyes.Remove(owner)
+						else
+							if(!brainkill)
+								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+							owner.death()
+							brainkill = TRUE
+					else if(zone_precise in tonguestab_zones)
+						var/obj/item/organ/tongue/tongue_up_my_asshole = owner.getorganslot(ORGAN_SLOT_TONGUE)
+						if(tongue_up_my_asshole)
+							playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
+							owner.next_attack_msg += " <span class='crit'><b>Critical hit!</b> The tongue flies off in an arc!</span>"
+							owner.Stun(10)
+							tongue_up_my_asshole.forceMove(get_turf(owner))
+							tongue_up_my_asshole.Remove(owner)
+					else if(!(zone_precise in do_nothing_zones))
+						if(!brainkill)
+							playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
 						owner.death()
 						brainkill = TRUE
 					return TRUE

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -380,8 +380,8 @@
 							var/obj/item/organ/eyes/my_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
 							if(my_eyes)
 								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
-								owner.Stun(10)
-								owner.blind_eyes(10)
+								owner.Stun(5)
+								owner.blind_eyes(5)
 								if(zone_precise == BODY_ZONE_PRECISE_R_EYE)
 									my_eyes.right_poked = TRUE
 									if(!my_eyes.left_poked)
@@ -428,8 +428,8 @@
 						var/obj/item/organ/eyes/my_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
 						if(my_eyes)
 							playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
-							owner.Stun(10)
-							owner.blind_eyes(10)
+							owner.Stun(5)
+							owner.blind_eyes(5)
 							if(zone_precise == BODY_ZONE_PRECISE_R_EYE)
 								my_eyes.right_poked = TRUE
 								if(!my_eyes.left_poked)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -399,6 +399,7 @@
 									playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)
 								owner.death()
 								brainkill = TRUE
+							owner.update_fov_angles()
 						else if(zone_precise in tonguestab_zones)
 							var/obj/item/organ/tongue/tongue_up_my_asshole = owner.getorganslot(ORGAN_SLOT_TONGUE)
 							if(tongue_up_my_asshole)
@@ -442,6 +443,7 @@
 								my_eyes.forceMove(get_turf(owner))
 								my_eyes.Remove(owner)
 								qdel(my_eyes)
+							owner.update_fov_angles()
 						else
 							if(!brainkill)
 								playsound(owner, pick('sound/combat/crit.ogg'), 100, FALSE)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -31,6 +31,9 @@
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
 
+	var/left_poked = FALSE
+	var/right_poked = FALSE
+
 /obj/item/organ/eyes/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()
 	if(ishuman(owner))


### PR DESCRIPTION
## About The Pull Request

Eyestab will now poke out the eye you're aiming for, permanently altering the FOV of the affected. If both eyes are poked out, the eye gets gored, and thus removed from the owner. Eyestabs can still brainkill both only once the eyes get gored!
Tongue stab will now tear off the tongue instead, and will never instakill.
Nose stabs do nothing because I couldn't figure out a fun effect for them, maybe disfigurement could be done later?

## Why It's Good For The Game

Fuck instakills, being crippled is better.
