### PR TITLE
Area fixes + new area intro texts

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -611,7 +611,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * If the area has ambience, then it plays some ambience music to the ambience channel
   */
-/area/Entered(atom/movable/M, area/old_area)
+/area/Entered(atom/movable/M, atom/OldLoc)
 	set waitfor = FALSE
 	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, M)
 	SEND_SIGNAL(M, COMSIG_ENTER_AREA, src) //The atom that enters the area

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -611,7 +611,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * If the area has ambience, then it plays some ambience music to the ambience channel
   */
-/area/Entered(atom/movable/M, OldLoc)
+/area/Entered(atom/movable/M, area/old_area)
 	set waitfor = FALSE
 	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, M)
 	SEND_SIGNAL(M, COMSIG_ENTER_AREA, src) //The atom that enters the area
@@ -629,6 +629,18 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	if(first_time_text)
 		L.intro_area(src)
+
+	var/mob/living/living_arrived = M
+
+	if(istype(living_arrived) && living_arrived.client && !living_arrived.cmode)
+		//Ambience if combat mode is off
+		SSdroning.area_entered(src, living_arrived.client)
+		SSdroning.play_loop(src, living_arrived.client)
+		var/found = FALSE
+		for(var/datum/weather/rain/R in SSweather.curweathers)
+			found = TRUE
+		if(found)
+			SSdroning.play_rain(src, living_arrived.client)
 
 //	L.play_ambience(src)
 
@@ -747,18 +759,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /// A hook so areas can modify the incoming args (of what??)
 /area/proc/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
 	return flags
-
-/area/Entered(atom/movable/arrived, area/old_area)
-	var/mob/living/living_arrived = arrived
-	if(istype(living_arrived) && living_arrived.client && !living_arrived.cmode)
-		//Ambience if combat mode is off
-		SSdroning.area_entered(src, living_arrived.client)
-		SSdroning.play_loop(src, living_arrived.client)
-		var/found = FALSE
-		for(var/datum/weather/rain/R in SSweather.curweathers)
-			found = TRUE
-		if(found)
-			SSdroning.play_rain(src, living_arrived.client)
 
 /area/proc/on_joining_game(mob/living/boarder)
 	return

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -371,6 +371,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = null
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/exposed/manorgarri
+	first_time_text = "THE KEEP OF ROCKHILL"
 /area/rogue/outdoors/exposed/manorgarri
 	icon_state = "manorgarri"
 	droning_sound = 'sound/music/area/manorgarri.ogg'
@@ -514,6 +515,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/town
+	first_time_text = "THE TOWN OF ROCKHILL"
 /area/rogue/indoors/shelter/town
 	icon_state = "town"
 	droning_sound = 'sound/music/area/townstreets.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes area Entered proc being split in two for some reason. This overrode the first proc and ignored a vital `set waitfor= FALSE` line that caused pulling to lag across area boundaries.

Also, since area titles work now, added one for the town and the keep. This may also enable some mood / beauty things that I'm not sure how exactly they work and might cause some balance issues, so this potentially warrants a testmerge before a full merge.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes something broke.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
