### PR TITLE
Descending stairs now allow you to pull things through

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -130,11 +130,11 @@
 		if(based)
 			if(isliving(AM))
 				var/mob/living/L = AM
-//				var/pulling = L.pulling
-//				if(pulling)
-//					L.pulling.forceMove(newtarg)
+				var/pulling = L.pulling
+				if(pulling)
+					L.pulling.forceMove(newtarg)
 				L.forceMove(newtarg)
-//				L.start_pulling(pulling)
+				L.start_pulling(pulling)
 			else
 				AM.forceMove(newtarg)
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Uncomments code preventing stairs from bringing items that you are pulling with you when going down z-levels. Same as existing behavior when ascending stairs. 

Probably fixes https://github.com/Blackstone-SS13/BLACKSTONE/issues/504
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not sure why it was removed, but nothing seemed to break in tests.  
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
