### PR TITLE
Skincrafting changes (again)

### DIFF
--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -29,7 +29,7 @@
 /datum/crafting_recipe/roguetown/leather/waterskin
 	name = "waterskin"
 	result = /obj/item/reagent_containers/glass/bottle/waterskin
-	reqs = list(/obj/item/natural/hide = 3,
+	reqs = list(/obj/item/natural/hide = 1,
 				/obj/item/natural/fibers = 2)
 	sellprice = 45
 
@@ -132,11 +132,6 @@
 	result = /obj/item/natural/saddle
 	reqs = list(/obj/item/natural/hide = 2)
 
-/datum/crafting_recipe/roguetown/leather/vest
-	name = "leather vest"
-	result = /obj/item/clothing/suit/roguetown/armor/leather/vest
-	reqs = list(/obj/item/natural/hide = 2)
-
 /datum/crafting_recipe/roguetown/leather/whip
 	name = "leather whip"
 	result = /obj/item/rogueweapon/whip
@@ -146,13 +141,3 @@
 	name = "Drum"
 	result = /obj/item/rogue/instrument/drum
 	reqs = list(/obj/item/natural/hide = 1,/obj/item/grown/log/tree/small = 1)
-
-/datum/crafting_recipe/roguetown/leather/goblinhelmet
-	name = "goblin helmet"
-	result = /obj/item/clothing/head/roguetown/helmet/leather/goblin
-	reqs = list(/obj/item/natural/hide = 1)
-
-/datum/crafting_recipe/roguetown/leather/goblinarmor
-	name = "goblin armor"
-	result = /obj/item/clothing/suit/roguetown/armor/leather/goblin
-	reqs = list(/obj/item/natural/hide = 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> Removes goblin armor from skincrafting, goblins are not a race anymore. Makes waterskins a little cheaper, and removes duplicate leather vest craft.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->ignore branch name lol. Goblin armor = pointless bloat without gobs

