### PR TITLE
[SPLIT] Sarkness Extravaganza: Blacksmithes Nerf

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -41,30 +41,19 @@
 		
 		
 		if(H.mind)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, pick(1,2,3), TRUE) // If you can make a sword you can swing one.
-			H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, pick(2,2,3), TRUE) 
-			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, pick(0,1), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, pick(0,1,2), TRUE) // If you can make a sword you can swing one.
+			H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE) 	
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE) 
-			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE) // The strongest fists in the land.
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE) // The strongest fists in the land. -- Not anymore, fuck you.
 			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE) 
-			H.mind.adjust_skillrank(/datum/skill/misc/swimming, pick(0,0,1), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/climbing, pick(1,1,2), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/crafting, pick(1,2,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/masonry, pick(0,0,1), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/engineering, pick(2,2,3), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/reading, pick(1,2,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/sewing, pick(1,1,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/traps, pick(1,1,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/cooking, pick(0,0,1), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/blacksmithing, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 3, TRUE)
-			if(prob(50))
-				H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
-			H.change_stat("strength", 1)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, pick(1,2,2), TRUE)	
+			H.mind.adjust_skillrank(/datum/skill/craft/blacksmithing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 2, TRUE)
+			H.change_stat("strength", 1)	
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)
 			H.change_stat("speed", -1)
@@ -75,18 +64,17 @@
 		
 		
 		if(H.mind)
-			H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/blacksmithing, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-
-			if(prob(50))
-				H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE) // If you can make a sword you can swing one. Females too then in that case, b#tch.
 
 			H.change_stat("strength",  1)
-			H.change_stat("intelligence", -1)
+			H.change_stat("endurance", 2)
+			H.change_stat("constitution", 2)
 			H.change_stat("speed", -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Nerfed Male Blacksmith Pilgrim, Buffed Female Blacksmith Pilgrim so they're on par together and gives a breather/importance to the Weaponsmith/Armorer
Also buffed lightly weaponsmith/armorer

## Why It's Good For The Game

A huge disparity between both blacksmithes (credits to @wow5000) which made female blacksmithes unable to forge properly with the new Smithes PR while Male Smithes Pilgrims outclassed Armorer/Weaponsmiths, making these normally crucial role very much useless. This should offset the balance and make it an equal ground for the smithes pilgrims, and the armorer/weaponsmith while keeping advantage to males without being detrimental to females smithes players.
