### PR TITLE
Change Necra Patron description

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -46,7 +46,7 @@
 	name = "Necra"
 	domain = "Goddess of Death and the Afterlife"
 	desc = "The Veiled Lady, a feared but respected God who leads the dead."
-	worshippers = " Necromancers, The Dead, Gravekeepers"
+	worshippers = "The Dead, Gravekeepers"
 	mob_traits = list(RTRAIT_NOSTINK)
 	t1 = /obj/effect/proc_holder/spell/targeted/burialrite
 	t2 = /obj/effect/proc_holder/spell/targeted/churn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
As the title say
## Why It's Good For The Game

In the PR already merged [https://github.com/Blackstone-SS13/BLACKSTONE/pull/756](url), necromancers became zizo worshippers and based on the book [https://github.com/Blackstone-SS13/BLACKSTONE/blob/main/strings/books/tales14.json](url) it talks about Necra and a situation with the western necromancers, they don't seem allies, also Necra has the divine skill "Churn the Undead" , that burns and explode all the undead on their sight, so lore wise it seems the Necromancers are enemies of Necra and are not worshippers, it could create confusion between players that might think that necromancers are worshippers of the nine  or confuse future necromance players that they are going to play a friendly part of the 9 role.