### PR TITLE
Jumping QOL and refactors

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -292,7 +292,9 @@
 				return
 			if(INTENT_JUMP)
 				if(istype(src.loc, /turf/open/water))
-					to_chat(src, "<span class='warning'>I'm floating.</span>")
+					to_chat(src, "<span class='warning'>I'm floating in [get_turf(src)].</span>")
+					return
+				if(!A || QDELETED(A) || !A.loc)
 					return
 				if(A == src || A == src.loc)
 					return
@@ -306,8 +308,6 @@
 					return
 				if(lying)
 					to_chat(src, "<span class='warning'>I should stand up first.</span>")
-					return
-				if(!ismob(A) && !isturf(A))
 					return
 				if(A.z != src.z)
 					if(!HAS_TRAIT(src, RTRAIT_ZJUMP))

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -64,14 +64,36 @@ SUBSYSTEM_DEF(throwing)
 	var/last_move = 0
 	var/extra = FALSE
 
+/datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, force, callback, target_zone, extra)
+	. = ..()
+	src.thrownthing = thrownthing
+	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, PROC_REF(on_thrownthing_qdel))
+	src.target = target
+	src.target_turf = target_turf
+	src.init_dir = init_dir
+	src.maxrange = maxrange
+	src.speed = speed
+	src.thrower = thrower
+	src.diagonals_first = diagonals_first
+	src.force = force
+	src.callback = callback
+	src.target_zone = target_zone
+	src.extra = extra
+
 /datum/thrownthing/Destroy()
 	SSthrowing.processing -= thrownthing
 	thrownthing.throwing = null
 	thrownthing = null
 	target = null
 	thrower = null
-	callback = null
+	if(callback)
+		QDEL_NULL(callback) //It stores a reference to the thrownthing, its source. Let's clean that.
 	return ..()
+
+///Defines the datum behavior on the thrownthing's qdeletion event.
+/datum/thrownthing/proc/on_thrownthing_qdel(atom/movable/source, force)
+	SIGNAL_HANDLER
+	qdel(src)
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
@@ -112,7 +134,7 @@ SUBSYSTEM_DEF(throwing)
 			finalize()
 			return
 
-		AM.Move(step, get_dir(AM, step))
+		AM.Move(step, get_dir(AM, step), DELAY_TO_GLIDE_SIZE(1 / speed))
 
 		if (!AM.throwing) // we hit something during our move
 			finalize(hit = TRUE)
@@ -136,19 +158,21 @@ SUBSYSTEM_DEF(throwing)
 			if (A == target)
 				hit = TRUE
 				thrownthing.throw_impact(A, src)
+				if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
+					return //deletion should already be handled by on_thrownthing_qdel()
 				break
 		if (!hit)
 			thrownthing.throw_impact(get_turf(thrownthing), src)  // we haven't hit something yet and we still must, let's hit the ground.
+			if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
+				return //deletion should already be handled by on_thrownthing_qdel()
 			thrownthing.newtonian_move(init_dir)
 	else
 		thrownthing.newtonian_move(init_dir)
 
 	if(target)
 		thrownthing.throw_impact(target, src)
-
-	if(QDELETED(thrownthing))
-		qdel(src)
-		return
+		if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
+			return //deletion should already be handled by on_thrownthing_qdel()
 
 	if (callback)
 		callback.Invoke()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -587,6 +587,10 @@
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = FALSE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, extra = FALSE) //If this returns FALSE then callback will not be called.
 	. = FALSE
+
+	if(QDELETED(src))
+		CRASH("Qdeleted thing being thrown around.")
+
 	if (!target || speed <= 0)
 		return
 
@@ -622,20 +626,13 @@
 
 	. = TRUE // No failure conditions past this point.
 
-	var/datum/thrownthing/TT = new()
-	TT.thrownthing = src
-	TT.target = target
-	TT.target_turf = get_turf(target)
-	TT.init_dir = get_dir(src, target)
-	TT.maxrange = range
-	TT.speed = speed
-	TT.thrower = thrower
-	TT.diagonals_first = diagonals_first
-	TT.force = force
-	TT.callback = callback
-	TT.extra = extra
-	if(!QDELETED(thrower))
-		TT.target_zone = thrower.zone_selected
+	var/target_zone
+	if(QDELETED(thrower))
+		thrower = null //Let's not pass a qdeleting reference if any.
+	else
+		target_zone = thrower.zone_selected
+
+	var/datum/thrownthing/TT = new(src, target, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, force, callback, target_zone, extra)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
@@ -669,7 +666,6 @@
 			var/turf/above = get_step_multiz(curloc, UP)
 			if(istype(above, /turf/open/transparent/openspace))
 				forceMove(above)
-	spin = FALSE
 	if(spin)
 		SpinAnimation(5, 1)
 

--- a/code/game/objects/items/rogueitems/prostheticarm.dm
+++ b/code/game/objects/items/rogueitems/prostheticarm.dm
@@ -1,5 +1,5 @@
 /obj/item/bodypart/l_arm/rproesthetic
-	name = "wooden larm"
+	name = "wooden left arm"
 	desc = "A left arm of wood."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "prarm"
@@ -30,7 +30,7 @@
 		return 1
 
 /obj/item/bodypart/r_arm/rproesthetic
-	name = "wooden rarm"
+	name = "wooden right arm"
 	desc = "A right arm of wood."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "prarm"

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -82,6 +82,7 @@
 /obj/item/rogueweapon/flail/sflail
 	force = 40
 	icon_state = "flail"
+	desc = "This is a swift, steel flail. Strikes hard and far."
 	smeltresult = /obj/item/ingot/steel
 	minstr = 5
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -108,7 +108,7 @@
 	anchored = anchorvalue
 
 /obj/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force)
-	..()
+	. = ..()
 	if(obj_flags & FROZEN)
 		visible_message("<span class='danger'>[src] shatters into a million pieces!</span>")
 		qdel(src)

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -67,7 +67,7 @@
 /obj/structure/flora/newtree/attack_hand(mob/user)
 	if(isliving(user))
 		var/mob/living/L = user
-		if(L.stat != CONSCIOUS)
+		if(L.stat != CONSCIOUS || L.incapacitated() || !(L.mobility_flags & MOBILITY_STAND))
 			return
 		var/turf/target = get_step_multiz(user, UP)
 		if(!istype(target, /turf/open/transparent/openspace))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -668,11 +668,11 @@
 		return
 	if(resting)
 		if(!IsKnockdown() && !IsStun() && !IsParalyzed())
-			src.visible_message("<span class='info'>[src] stands up.</span>")
+			src.visible_message("<span class='info'>[src] begins to stand up.</span>")
 			if(move_after(src, 20, target = src))
 				set_resting(FALSE, FALSE)
 		else
-			src.visible_message("<span class='warning'>[src] tries to stand up.</span>")
+			src.visible_message("<span class='warning'>[src] struggles to stand up.</span>")
 	else
 		set_resting(TRUE, FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
You can now jump towards any atom. Should be easier to leap around the place.

Additional changes:
- Removes some hard deleting sources in throwing
- Adds initializing throwing datums with New()
- Parent of object throw_at now passes value down
- More checks on climbing trees
- Spin animation while throwing is now possible, but still off by default
- Some text changes

"Fixes" https://github.com/Blackstone-SS13/BLACKSTONE/issues/946 (wasn't exactly a bug).
## Why It's Good For The Game
Easier jumping and better code.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
