### PR TITLE
Making more things repairable, including containers.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -553,7 +553,7 @@
 			var/obj/item/storage/this_item = parent
 			//Vrell - since hammering is instant, i gotta find another option than the double click thing that needle has for a bypass.
 			//Thankfully, IIRC, no hammerable containers can hold a hammer, so not an issue ATM. For that same reason, this here is largely semi future-proofing.
-			if(this_item.anvilrepair != null && this_item.max_integrity && !this_item.obj_broken && this_item.obj_integrity < this_item.max_integrity)
+			if(this_item.anvilrepair != null && this_item.max_integrity && !this_item.obj_broken && (this_item.obj_integrity < this_item.max_integrity) && isturf(this_item.loc))
 				return FALSE
 		if(istype(I, /obj/item/needle))
 			var/obj/item/needle/sewer = I

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -69,6 +69,9 @@
 
 	var/not_while_equipped = FALSE
 
+	//Vrell - Used for repair bypass clicks
+	var/being_repaired = FALSE
+
 /datum/component/storage/Initialize(datum/component/storage/concrete/master)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -544,6 +547,21 @@
 //	. = TRUE //no afterattack
 	if(iscyborg(M))
 		return
+	//Vrell - Adding a block here to allow sewing/hammering to repair containers. Clicking while trying to sew will bypass this requirement.
+	if(isitem(parent))
+		if(istype(I, /obj/item/rogueweapon/hammer))
+			var/obj/item/storage/this_item = parent
+			//Vrell - since hammering is instant, i gotta find another option than the double click thing that needle has for a bypass.
+			//Thankfully, IIRC, no hammerable containers can hold a hammer, so not an issue ATM. For that same reason, this here is largely semi future-proofing.
+			if(this_item.anvilrepair != null && this_item.max_integrity && !this_item.obj_broken && this_item.obj_integrity < this_item.max_integrity)
+				return FALSE
+		if(istype(I, /obj/item/needle))
+			var/obj/item/needle/sewer = I
+			var/obj/item/storage/this_item = parent
+			if(sewer.can_repair && this_item.sewrepair && this_item.max_integrity && !this_item.obj_broken && this_item.obj_integrity < this_item.max_integrity && M.mind.get_skill_level(/datum/skill/misc/sewing) >= this_item.required_repair_skill && this_item.ontable() && !being_repaired)
+				being_repaired = TRUE
+				return FALSE
+	being_repaired = FALSE
 	if(!can_be_inserted(I, FALSE, M))
 		var/atom/real_location = real_location()
 		if(real_location.contents.len >= max_items) //don't use items on the backpack if they don't fit

--- a/code/game/objects/items/rogueitems/cup.dm
+++ b/code/game/objects/items/rogueitems/cup.dm
@@ -15,6 +15,7 @@
 	sellprice = 1
 	drinksounds = list('sound/items/drink_cup (1).ogg','sound/items/drink_cup (2).ogg','sound/items/drink_cup (3).ogg','sound/items/drink_cup (4).ogg','sound/items/drink_cup (5).ogg')
 	fillsounds = list('sound/items/fillcup.ogg')
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/reagent_containers/glass/cup/update_icon(dont_fill=FALSE)
 	testing("cupupdate")
@@ -34,6 +35,7 @@
 	resistance_flags = FLAMMABLE
 	icon_state = "wooden"
 	drop_sound = 'sound/foley/dropsound/wooden_drop.ogg'
+	anvilrepair = null
 
 /obj/item/reagent_containers/glass/cup/steel
 	name = "goblet"

--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -31,6 +31,7 @@
 	var/loaded = TRUE
 	var/lastfilechange = 0
 	var/curvol = 100
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/dmusicbox/Initialize()
 	soundloop = new(list(src), FALSE)

--- a/code/game/objects/items/rogueitems/flintsparker.dm
+++ b/code/game/objects/items/rogueitems/flintsparker.dm
@@ -10,6 +10,7 @@
 	obj_flags = null
 	icon = 'icons/roguetown/items/lighting.dmi'
 	var/flintcd = 0
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/flint/attack_self(mob/living/user)
 	if(world.time < flintcd + 10)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -12,6 +12,7 @@
 	throwforce = 0
 	var/list/keys = list()
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_MOUTH|ITEM_SLOT_WRISTS
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/keyring/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -12,6 +12,7 @@
 	var/lockhash = 0
 	var/lockid = null
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH|ITEM_SLOT_NECK
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/roguekey/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -17,6 +17,7 @@
 	var/infinite = FALSE
 	/// If this needle can be used to repair items
 	var/can_repair = TRUE
+	anvilrepair = /datum/skill/craft/blacksmithing
 
 /obj/item/needle/examine()
 	. = ..()
@@ -62,11 +63,22 @@
 			var/sewtime = 70
 			if(user.mind)
 				sewtime = (70 - ((user.mind.get_skill_level(/datum/skill/misc/sewing)) * 10))
+			var/datum/component/storage/target_storage = I.GetComponent(/datum/component/storage) //Vrell - Part of storage item repair fix
 			if(do_after(user, sewtime, target = I))
 				playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 				user.visible_message("<span class='info'>[user] repairs [I]!</span>")
 				I.obj_integrity = I.max_integrity
+				//Vrell - Part of storage item repair fix
+				if(target_storage) {
+					target_storage.being_repaired = FALSE
+				}
 				return
+			else {
+				//Vrell - Part of storage item repair fix
+				if(target_storage) {
+					target_storage.being_repaired = FALSE
+				}
+			}
 		return
 	return ..()
 
@@ -128,6 +140,7 @@
 	icon_state = "thornneedle"
 	desc = "This rough needle can be used to sew cloth and wounds."
 	stringamt = 3
+	anvilrepair = null
 
 /obj/item/needle/pestra
 	name = "needle of pestra"

--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -18,6 +18,7 @@
 	possible_item_intents = list(/datum/intent/tie)
 	firefuel = 5 MINUTES
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
+	sewrepair = TRUE
 
 /datum/intent/tie
 	name = "tie"
@@ -141,3 +142,5 @@
 	firefuel = null
 	smeltresult = /obj/item/ingot/iron
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
+	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/blacksmithing

--- a/code/game/objects/items/rogueitems/undies.dm
+++ b/code/game/objects/items/rogueitems/undies.dm
@@ -13,6 +13,7 @@
 	var/gendered = MALE
 	var/race
 	var/cached_undies
+	sewrepair = TRUE
 
 /obj/item/undies/f
 	name = "women's smallclothes"

--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -17,4 +17,5 @@
 	drinksounds = list('sound/items/drink_bottle (1).ogg','sound/items/drink_bottle (2).ogg')
 	fillsounds = list('sound/items/fillcup.ogg')
 	poursounds = list('sound/items/fillbottle.ogg')
+	sewrepair = TRUE
 

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -4,6 +4,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/rummage_if_nodrop = TRUE
 	var/component_type = /datum/component/storage/concrete
+	obj_flags = CAN_BE_HIT
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
 	return src

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -7,6 +7,7 @@
 	edelay_type = 1
 	equip_delay_self = 10
 	bloody_icon_state = "bodyblood"
+	sewrepair = TRUE //Vrell - AFAIK, all cloaks are cloth ATM. Technically semi-less future-proof, but it removes a line of code from every subtype, which is worth it IMO.
 
 
 //////////////////////////

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -20,6 +20,7 @@
 	gender = PLURAL
 	icon_state = "blackboots"
 	item_state = "blackboots"
+	sewrepair = TRUE
 	armor = list("melee" = 15, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/shoes/roguetown/nobleboot
@@ -30,6 +31,7 @@
 	gender = PLURAL
 	icon_state = "nobleboots"
 	item_state = "nobleboots"
+	sewrepair = TRUE
 	armor = list("melee" = 15, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/shoes/roguetown/shortboots
@@ -39,6 +41,7 @@
 	gender = PLURAL
 	icon_state = "shortboots"
 	item_state = "shortboots"
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/ridingboots
 	name = "riding boots"
@@ -47,6 +50,7 @@
 	gender = PLURAL
 	icon_state = "ridingboots"
 	item_state = "ridingboots"
+	sewrepair = TRUE
 
 ///obj/item/clothing/shoes/roguetown/ridingboots/Initialize()
 //	. = ..()
@@ -58,6 +62,7 @@
 	gender = PLURAL
 	icon_state = "simpleshoe"
 	item_state = "simpleshoe"
+	sewrepair = TRUE
 	resistance_flags = null
 	color = "#473a30"
 
@@ -85,6 +90,7 @@
 	gender = PLURAL
 	icon_state = "gladiator"
 	item_state = "gladiator"
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/sandals
 	name = "sandals"
@@ -92,6 +98,7 @@
 	gender = PLURAL
 	icon_state = "sandals"
 	item_state = "sandals"
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/shalal
 	name = "babouche"
@@ -99,6 +106,7 @@
 	gender = PLURAL
 	icon_state = "shalal"
 	item_state = "shalal"
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/boots/armor
 	name = "plated boots"
@@ -120,9 +128,11 @@
 	gender = PLURAL
 	icon_state = "leatherboots"
 	item_state = "leatherboots"
+	sewrepair = TRUE
 	armor = list("melee" = 15, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/shoes/roguetown/jester
 	name = "funny shoes"
 	icon_state = "jestershoes"
 	resistance_flags = null
+	sewrepair = TRUE

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -32,6 +32,7 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	max_integrity = 100
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/roguehood/shalal
 	name = "keffiyeh"
@@ -86,6 +87,7 @@
 	item_state = "necrahood"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/dendormask
 	name = "briarmask"
@@ -94,6 +96,7 @@
 	item_state = "dendormask"
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/necromhood
 	name = "necromancers hood"
@@ -103,6 +106,7 @@
 	body_parts_covered = NECK
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/priestmask
 	name = "solar visage"
@@ -112,6 +116,7 @@
 	item_state = "priesthead"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/priestmask/pickup(mob/living/user)
 	if((user.job != "Priest") && (user.job != "Priestess"))
@@ -163,6 +168,7 @@
 	item_state = "menacing"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	dynamic_hair_suffix = ""
+	sewrepair = TRUE
 	//dropshrink = 0.75
 
 /obj/item/clothing/head/roguetown/menacing/bandit
@@ -173,41 +179,50 @@
 	icon_state = "jester"
 	item_state = "jester"
 	dynamic_hair_suffix = "+generic"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/strawhat
 	name = "straw hat"
 	icon_state = "strawhat"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/puritan
 	name = "buckled hat"
 	icon_state = "puritan_hat"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/nightman
 	name = "teller's hat"
 	icon_state = "tophat"
 	color = CLOTHING_BLACK
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/bardhat
 	name = "hat"
 	icon_state = "bardhat"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/fancyhat
 	name = "fancy hat"
 	icon_state = "fancy_hat"
 	item_state = "fancyhat"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/hatfur
 	name = "fur hat"
 	icon_state = "hatfur"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/hatblu
 	name = "fur hat"
 	icon_state = "hatblu"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/fisherhat
 	name = "straw hat"
 	icon_state = "fisherhat"
 	item_state = "fisherhat"
+	sewrepair = TRUE
 //	color = "#fbc588"
 	//dropshrink = 0.75
 
@@ -215,6 +230,7 @@
 	name = "flat hat"
 	icon_state = "flathat"
 	item_state = "flathat"
+	sewrepair = TRUE
 
 
 /obj/item/clothing/head/roguetown/chaperon
@@ -222,6 +238,7 @@
 	icon_state = "chaperon"
 	item_state = "chaperon"
 	flags_inv = HIDEEARS
+	sewrepair = TRUE
 	//dropshrink = 0.75
 
 /obj/item/clothing/head/roguetown/cookhat
@@ -229,6 +246,7 @@
 	icon_state = "chef"
 	item_state = "chef"
 	flags_inv = HIDEEARS
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/chaperon/greyscale
 	name = "chaperon hat"
@@ -254,6 +272,7 @@
 /obj/item/clothing/head/roguetown/chef
 	name = "chef's hat"
 	icon_state = "chef"
+	sewrepair = TRUE
 	//dropshrink = 0.75
 
 /obj/item/clothing/head/roguetown/armingcap
@@ -261,11 +280,13 @@
 	icon_state = "armingcap"
 	item_state = "armingcap"
 	flags_inv = HIDEEARS
+	sewrepair = TRUE
 	//dropshrink = 0.75
 
 /obj/item/clothing/head/roguetown/knitcap
 	name = "knit cap"
 	icon_state = "knitcap"
+	sewrepair = TRUE
 	//dropshrink = 0.75
 
 /obj/item/clothing/head/roguetown/armingcap/dwarf
@@ -275,6 +296,7 @@
 	name = "headband"
 	icon_state = "headband"
 	item_state = "headband"
+	sewrepair = TRUE
 	//dropshrink = 0.75
 	dynamic_hair_suffix = null
 
@@ -289,6 +311,7 @@
 	dynamic_hair_suffix = null
 	sellprice = 200
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/Initialize()
 	. = ..()
@@ -308,6 +331,7 @@
 	dynamic_hair_suffix = null
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	sellprice = 50
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/head/roguetown/priesthat
 	name = "priest's hat"
@@ -319,6 +343,7 @@
 	sellprice = 77
 	worn_x_dimension = 64
 	worn_y_dimension = 64
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/reqhat
 	name = "serpent crown"
@@ -326,26 +351,31 @@
 	icon_state = "reqhat"
 	flags_inv = HIDEEARS
 	sellprice = 100
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/head/roguetown/headdress
 	name = "foreign headdress"
 	desc = ""
 	icon_state = "headdress"
 	sellprice = 10
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/headdress/alt
 	icon_state = "headdressalt"
+	sewrepair
 
 /obj/item/clothing/head/roguetown/nun
 	name = "nun's habit"
 	icon_state = "nun"
 	sellprice = 5
+	sewrepair
 
 /obj/item/clothing/head/roguetown/hennin
 	name = "hennin"
 	icon_state = "hennin"
 	sellprice = 19
 	dynamic_hair_suffix = "+generic"
+	sewrepair
 
 /obj/item/clothing/head/roguetown/paddedcap
 	name = "padded cap"
@@ -360,6 +390,7 @@
 	blocksound = SOFTHIT
 	max_integrity = 75
 	color = "#463C2B"
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/helmet
 	icon = 'icons/roguetown/clothing/head.dmi'
@@ -379,7 +410,6 @@
 	smeltresult = /obj/item/ingot/steel
 	blocksound = PLATEHIT
 	max_integrity = 200
-
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
 	name = "skull cap"
@@ -640,6 +670,7 @@
 	sellprice = 100
 	worn_x_dimension = 64
 	worn_y_dimension = 64
+	sewrepair = TRUE
 
 /obj/item/clothing/head/roguetown/wizhat/gen
 	icon_state = "wizardhatgen"
@@ -674,3 +705,4 @@
 	dynamic_hair_suffix = null
 	sellprice = 100
 	resistance_flags = FIRE_PROOF
+	anvilrepair = /datum/skill/craft/armorsmithing

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -14,6 +14,7 @@
 	integrity_failure = 0.5
 	resistance_flags = FIRE_PROOF
 	body_parts_covered = EYES
+	anvilrepair = /datum/skill/craft/armorsmithing
 //	block2add = FOV_BEHIND
 
 /obj/item/clothing/mask/rogue/spectacles/golden
@@ -25,6 +26,7 @@
 	integrity_failure = 0.5
 	resistance_flags = FIRE_PROOF
 	body_parts_covered = EYES
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/mask/rogue/spectacles/Initialize()
 	. = ..()
@@ -50,6 +52,7 @@
 	max_integrity = 20
 	integrity_failure = 0.5
 	block2add = FOV_RIGHT
+	sewrepair = TRUE
 
 /obj/item/clothing/mask/rogue/eyepatch/left
 	desc = "An eyepatch, fitted for the left eye."
@@ -61,6 +64,7 @@
 	desc = "Half of your face turned gold."
 	icon_state = "lmask"
 	sellprice = 50
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/mask/rogue/lordmask/l
 	icon_state = "lmask_l"
@@ -109,6 +113,7 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	experimental_onhip = TRUE
+	sewrepair = TRUE
 
 /obj/item/clothing/mask/rogue/shepherd/AdjustClothes(mob/user)
 	if(loc == user)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -16,6 +16,7 @@
 	armor = list("melee" = 12, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
+	sewrepair = TRUE
 
 /obj/item/clothing/neck/roguetown/coif/AdjustClothes(mob/user)
 	if(loc == user)
@@ -123,6 +124,7 @@
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HIP|ITEM_SLOT_WRISTS
 	sellprice = 10
 	experimental_onhip = TRUE
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/neck/roguetown/psicross/astrata
 	name = "amulet of Astrata"
@@ -198,6 +200,7 @@
 	resistance_flags = FIRE_PROOF
 	allowed_race = list("human", "dwarf", "elf", "tiefling", "aasimar", "goblinp", "halforc")
 	sellprice = 98
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/neck/roguetown/horus
 	name = "eye of horuz"
@@ -206,6 +209,7 @@
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
 	sellprice = 30
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/neck/roguetown/shalal
 	name = "desert rider medal"
@@ -214,3 +218,4 @@
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
 	sellprice = 15
+	anvilrepair = /datum/skill/craft/armorsmithing

--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -17,6 +17,7 @@
 	strip_delay = 20
 	var/max_storage = 20
 	var/list/arrows = list()
+	sewrepair = TRUE
 
 /obj/item/quiver/attackby(obj/A, loc, params)
 	if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue))

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -11,6 +11,7 @@
 	icon_state = ""
 	slot_flags = ITEM_SLOT_RING
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/ring/silver
 	name = "silver ring"

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -36,6 +36,7 @@
 	item_state = "leather"
 	equip_sound = 'sound/blank.ogg'
 	heldz_items = 3
+	sewrepair = TRUE
 
 /obj/item/storage/belt/rogue/leather/dropped(mob/living/carbon/human/user)
 	..()
@@ -49,6 +50,8 @@
 	name = "plaque belt"
 	icon_state = "goldplaque"
 	sellprice = 50
+	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/storage/belt/rogue/leather/shalal
 	name = "shalal belt"
@@ -64,11 +67,15 @@
 	name = "plaque belt"
 	icon_state = "silverplaque"
 	sellprice = 30
+	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/storage/belt/rogue/leather/hand
 	name = "steel belt"
 	icon_state = "steelplaque"
 	sellprice = 30
+	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/storage/belt/rogue/leather/rope
 	name = "rope belt"
@@ -106,6 +113,7 @@
 	equip_sound = 'sound/blank.ogg'
 	content_overlays = FALSE
 	bloody_icon_state = "bodyblood"
+	sewrepair = TRUE
 
 /obj/item/storage/belt/rogue/pouch/ComponentInitialize()
 	. = ..()
@@ -173,6 +181,7 @@
 	equip_sound = 'sound/blank.ogg'
 	bloody_icon_state = "bodyblood"
 	alternate_worn_layer = UNDER_CLOAK_LAYER
+	sewrepair = TRUE
 
 /obj/item/storage/backpack/rogue/satchel/heartfelt/PopulateContents()
 	new /obj/item/natural/feather(src)
@@ -209,6 +218,7 @@
 	max_integrity = 300
 	equip_sound = 'sound/blank.ogg'
 	bloody_icon_state = "bodyblood"
+	sewrepair = TRUE
 
 /obj/item/storage/backpack/rogue/backpack/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -39,9 +39,11 @@
 	slot_flags = ITEM_SLOT_WRISTS
 	icon_state = "wrappings"
 	item_state = "wrappings"
+	sewrepair = TRUE
 
 /obj/item/clothing/wrists/roguetown/nocwrappings
 	name = "moon wrappings"
 	slot_flags = ITEM_SLOT_WRISTS
 	icon_state = "nocwrappings"
 	item_state = "nocwrappings"
+	sewrepair = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added the ability to repair many more items than could originally be done:
- Added the ability to be repaired, via either hammer or needle, to all non-wooden items in modules/clothing/rogueclothes
  - Notably all cloaks, shoes, hats, masks, neckware, quivers, rings, shirts, belts, and bags.
 -  Added the ability to repair most non-wooden items, via either hammer or needle, within game/objects/items/rogueitems
 - Modified the behaviour of storage objects and needles in order to allow you to sew or hammer storage containers so you can repair them, with a bypass by clicking again on the storage container while you are sewing it if you wanna store your needle without repairing the container.

There are some flaws with this setup that I want to acknowledge:
- A quick double click doesn't store the needle: a short delay between clicks is required. I'll look into a fix for this if it's an issue.
- There is currently no way to store a hammer in a repairable container that is on the floor or on a table. It can be stored if you carry the container though, which should be fine enough as an option for players IMO, especially given the general lack of metallic containers.
- Some items can't be attacked, and thus can't be repaired. Most are not likely to be a concern for taking damage though and I had gone in and changed every item I've seen damaged while playing the game in this regard. That might have an unforeseen side effect though.
- I've only done limited testing on this so far, but it seems to work. I'm mainly sending this now so others can look at it and judge it since I have limited experience with dreammaker, and as a nice send-off point before I go to bed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was a change suggested in the discord that I decided to make for my first PR. It will make it actually possible to repair those pouches and cloaks you find that have taken damage, that way they look proper and new when examined and there isn't worry that you'll lose them to damage in the case of some things, like leather boots which used to be able to be destroyed and damaged in combat but could never be repaired. It's also not a huge change, so it shouldn't need too much reason beyond this: most of the items that were super important to repair before this were already repairable.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->