### PR TITLE
Gives Faith Test to the Witch Hunter, Gives Medium Armor Trait to the Inquisitor

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
@@ -55,5 +55,7 @@
 		H.change_stat("constitution", 1)
 		H.change_stat("perception", 2)
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
+	H.verbs |= /mob/living/carbon/human/proc/faith_test
+
 	ADD_TRAIT(H, RTRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -79,6 +79,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	ADD_TRAIT(H, RTRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	ADD_TRAIT(H, RTRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 /mob/living/carbon/human/proc/torture_victim()
 	set name = "Extract Confession"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The title

## Why It's Good For The Game

Inquisitor is a hired Witch Hunter, and a Witch Hunter would ofcourse also be able to test someone Faith.

For a role given so many stats and skills it quites fails in being able to use a good armor, especially a role that sometimes must go alone to search for vampire or werewolves sights, being forced to not being able to run or use weaker armor, without this buff it would stay in the midle, combat capable but not so much, being forced to stay around people with good armor and weapons that is not always the case since the church is busy with other stuff, the same way Templars still got their armor trait from Paladin it makes sense that even a Witch hunter that is accommodated in a town still retain their training from using medium armor, this way the Inquisitors players may go on adventures better armored and get more results rather than dying to a vampire or werewolf in seconds because of their weak armor.
