### PR TITLE
Adds the crafting datum for Mantraps (Beartraps)

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -352,7 +352,7 @@
 				update_icon()
 				to_chat(user, "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"]</span>")
 			else
-				user.visible_message("<span class='warning'>You couldn't get the shoddy [src.name] to open up!</span>")
+				user.visible_message("<span class='warning'>You couldn't get the shoddy [src.name] [armed ? "shut close!" : "to open up!"]</span>")
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap()
 	armed = FALSE
 	alpha = 255

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -352,9 +352,7 @@
 				update_icon()
 				to_chat(user, "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"]</span>")
 			else
-				user.visible_message("<span class='warning'>The rusty [src.name] breaks under stress!</span>")
-				playsound(src.loc, 'sound/foley/breaksound.ogg', 100, TRUE, -1)
-				qdel(src)
+				user.visible_message("<span class='warning'>You couldn't get the shoddy [src.name] to open up!</span>")
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap()
 	armed = FALSE
 	alpha = 255

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -266,3 +266,11 @@
 	result = /obj/item/clothing/neck/roguetown/psicross/wood
 	reqs = list(/obj/item/natural/fibers = 2,
 				/obj/item/grown/log/tree/stick = 2)
+
+/datum/crafting_recipe/roguetown/mantrap
+	name = "mantrap"
+	result = /obj/item/restraints/legcuffs/beartrap
+	reqs = list(/obj/item/grown/log/tree/small = 1)
+	skillcraft = /datum/skill/craft/traps
+	craftdiff = 1
+	verbage = "put together"

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -269,9 +269,11 @@
 
 /datum/crafting_recipe/roguetown/mantrap
 	name = "mantrap"
-	result = /obj/item/restraints/legcuffs/beartrap
-	reqs = list(/obj/item/grown/log/tree/small = 2,
-				/obj/item/rope = 1)
+	result = list(/obj/item/restraints/legcuffs/beartrap,
+				/obj/item/restraints/legcuffs/beartrap)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/natural/fibers = 2,
+				/obj/item/ingot/iron = 1)
 	req_table = TRUE
 	skillcraft = /datum/skill/craft/traps
 	craftdiff = 1

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -270,7 +270,9 @@
 /datum/crafting_recipe/roguetown/mantrap
 	name = "mantrap"
 	result = /obj/item/restraints/legcuffs/beartrap
-	reqs = list(/obj/item/grown/log/tree/small = 1)
+	reqs = list(/obj/item/grown/log/tree/small = 2,
+				/obj/item/rope = 1)
+	req_table = TRUE
 	skillcraft = /datum/skill/craft/traps
 	craftdiff = 1
 	verbage = "put together"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request: 
Adds the crafting datum for mantraps. A variant of beartraps that need time to set up, and can break under stress from doing so. The crafting recipe takes one small log (Subject to change) and uses the trapsmaking skill, with a difficulty of crafting of 1 (Subject to change, plus 10 int characters, plus 8 int characters with smokeweed and characters with novice trapmaking can make the trap). 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Adds another item into the game, with clear counterplay (Jumping over it/going around it/using the look around verb) and makes the trapmaking skill useful for making traps. Perfect for anyone who can't fight directly, as this will cover an escape (If you're quick enough to get it from your satchel) or at least slow down any would be pursuers. 
