### PR TITLE
Unshittify studded leather armor

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -325,6 +325,7 @@
 	icon_state = "studleather"
 	item_state = "studleather"
 	blocksound = SOFTHIT
+	armor = list("melee" = 50, "bullet" = 15, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_CHOP)
 	nodismemsleeves = TRUE
 	body_parts_covered = CHEST|GROIN|VITALS


### PR DESCRIPTION
## About The Pull Request

Doubles melee resist to 50 and adds a tiny bit more ranged resist up to 15 for studded leather armor.

## Why It's Good For The Game

It was originally just regular leather armor in protection values. Strange for an armor piece that requires 2 professionals and the combination of both metal and hides to be just as shitty as its original un-upgraded version, other than more integrity and chop resistance. Worthless.

At 50 melee resist, pretty much all dedicated stab weapons (polearms, daggers, etc) still bypass it or mostly bypass it. This makes the armor actually work like an effective upgrade, but potentially still be penned like light armor should with the right weapon rather than **every** weapon.