### PR TITLE
Wooden cross sell value set to 0

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -153,6 +153,7 @@
 /obj/item/clothing/neck/roguetown/psicross/wood
 	name = "wooden psycross"
 	icon_state = "psicrossw"
+	sellprice = 0
 
 /obj/item/clothing/neck/roguetown/psicross/silver
 	name = "silver psycross"


### PR DESCRIPTION
## About The Pull Request

Fixes infinite money craft recipe from making wooden crosses.

## Why It's Good For The Game

Jank wooden psycrosses should not have any value. Regular patron specific and psycrosses are made of actually valuable material and only worth 10. This also meant bandits could just craft them to sell to matthios instead of being bandits.