### PR TITLE
Flail iron/steel damage sanity

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -1,5 +1,5 @@
 /obj/item/rogueweapon/flail
-	force = 12
+	force = 15
 	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/flail/strike/smash)
 	name = "flail"
 	desc = "This is a swift, iron flail. Strikes hard and far."
@@ -80,7 +80,7 @@
 
 
 /obj/item/rogueweapon/flail/sflail
-	force = 40
+	force = 30
 	icon_state = "flail"
 	desc = "This is a swift, steel flail. Strikes hard and far."
 	smeltresult = /obj/item/ingot/steel


### PR DESCRIPTION
## About The Pull Request

Increases Iron Flail to 15 force from 12 and reduces Steel Flail to 30 force from 40.

## Why It's Good For The Game

This was the most egregious gap in damage that everyone already acknowledged but nobody did anything about yet. Keep in mind that flail smash is the only attack of its kind to my knowledge that has no swingdelay, just a very short windup, making it particularly oppressive. Also: **No armor has smash crit prevention** Wearing full plate armor? First swing to the chest breaks your ribs or knocks you out with a head hit while wearing a knight full helm.

10 strength with iron flail on smash was doing 18 damage of which none will get through the usual 100 melee armor.
10 strength with steel flail on smash was doing 60 damage of which 40 gets through. 1 handed. 1 steel bar. 15 strength?  90 damage, with 70 getting through.

With the new values, iron flail will do 23 damage on smash at 10 strength. Just enough to feel something. It will actually hurt with more strength.
Steel flail is still a monster, doing 45 on smash at 10 strength, putting through 25 damage after armor resists.

Frankly, some higher quality armor needs smash crit prevention for this to not still be bullshit. I'll think it over.