### PR TITLE
Warrior subclasses rework

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -21,33 +21,33 @@
 /datum/outfit/job/roguetown/adventurer/sfighter/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Warrior","Monster Hunter",) // To Do - knight errant unique archetype(5 percent chance)
+	var/classes = list("Mighty Warrior","Swift Warrior",) // To Do - knight errant unique archetype(5 percent chance)
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
 	
-		if("Warrior")
+		if("Mighty Warrior")
 			H.set_blindness(0)
-			to_chat(H, "<span class='warning'>Warriors are well rounded fighters, experienced often in many theaters of warfare and battle they are capable of rising to any challenge that might greet them on the path.</span>")
-			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, rand(1,2), TRUE)
+			to_chat(H, "<span class='warning'>Strong and tough, Mighty Warriors are ready to crush their opponents under their mace while wearing heavy armor.</span>")
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/bows, rand(1,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, rand(1,3), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, pick(1,1,2), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, rand(1,2), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/riding, pick(2,3), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-			H.change_stat("strength", 2)
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			H.change_stat("strength", 3)
 			H.change_stat("endurance", 2) // 7 stat points total as a low-skill martial role without magic. Compared to Pally with 5 points.
 			H.change_stat("constitution", 2)
-			H.change_stat("speed", 1)
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			gloves = /obj/item/clothing/gloves/roguetown/leather
 			belt = /obj/item/storage/belt/rogue/leather
@@ -60,10 +60,8 @@
 			else
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
 			if(prob(20))
-				mask = /obj/item/clothing/mask/rogue/facemask
-			else if(prob(60))
 				head = /obj/item/clothing/head/roguetown/helmet/leather
-			else if(prob(20))
+			else if(prob(50))
 				head = /obj/item/clothing/head/roguetown/helmet/skullcap
 			else
 				head = /obj/item/clothing/head/roguetown/helmet/kettle
@@ -71,53 +69,53 @@
 			backr = /obj/item/rogueweapon/shield/wood
 			beltl = /obj/item/rogueweapon/huntingknife
 			if(prob(50))
-				beltr = /obj/item/rogueweapon/sword/iron
-			else
-				beltr = /obj/item/rogueweapon/sword/sabre
-		if("Monster Hunter")
+				beltr = /obj/item/rogueweapon/mace/
+		if("Swift Warrior")
 			H.set_blindness(0)
-			to_chat(H, "<span class='warning'>Monsters Hunters are typically contracted champions of the common folk dedicated to the slaying of both lesser vermin and greater beasts of the wilds.</span>")
-			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, rand(1,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/bows, rand(1,2), TRUE)
+			to_chat(H, "<span class='warning'>Swift Warriors are able to evade their opponents while executing precise strikes, but only wear light armor.</span>")
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, rand(1,3), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, pick(1,1,2), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, pick(2,2,3), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/riding, pick(2,3), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-			H.change_stat("strength", 2)
-			H.change_stat("endurance", 1) // Weaker endurance compared to a traditional warrior/soldier. Smarter due to study of rare magical beasts.
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)
-			H.change_stat("intelligence", 1)
-			H.change_stat("speed", 1)
+			H.change_stat("speed", 2)
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			gloves = /obj/item/clothing/gloves/roguetown/leather
 			belt = /obj/item/storage/belt/rogue/leather
 			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
-			if(prob(40))
-				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
-				H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-				backr = /obj/item/rogueweapon/sword/long
-			else if(prob(60))
-				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
-				H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-				r_hand = /obj/item/rogueweapon/spear/billhook
-			else
-				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale // No helms for monster hunters.
-				H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-				H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
-				backr = /obj/item/rogueweapon/stoneaxe/battle
 			backl = /obj/item/storage/backpack/rogue/satchel
-			beltl = /obj/item/rogueweapon/huntingknife
+			if(prob(33))
+				head = /obj/item/clothing/head/roguetown/helmet/leather
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+				pants = /obj/item/clothing/under/roguetown/trou/leather
+				belt2 = /obj/item/rogueweapon/sword/sabre
+				beltl = /obj/item/rogueweapon/huntingknife
+			else if(prob(50))
+				belt1 = /obj/item/rogueweapon/huntingknife/idagger/steel				
+				belt2 = /obj/item/rogueweapon/huntingknife/idagger/steel
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				pants = /obj/item/clothing/under/roguetown/trou/leather
+			else
+				belt2 = /obj/item/rogueweapon/sword/sabre
+				beltl = /obj/item/rogueweapon/huntingknife
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				pants = /obj/item/clothing/under/roguetown/trou/leather
+
 	if(H.gender == MALE)
 		pants = /obj/item/clothing/under/roguetown/tights/black
 	else
@@ -126,5 +124,3 @@
 		H.update_body()
 		pants = /obj/item/clothing/under/roguetown/tights/black
 
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changes warrior classes to be a choice between Mighty Warriors, who use maces/axes and heavy armor, and Swift Warriors, who use blades and light armor.

This is a pretty broad-reaching change, which involves creating two new sub-classes for the Warrior. Mighty Warrior is not too different from the original Warrior, but Swift Warrior is a large change, with no Str bonus but more Speed, higher skills, and don't get armor proficiencies.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Right now, Warriors are in a weird place. They have marginally higher stats than other characters, but not better combat skills and MUCH worse skills overall. Almost all other adventurer classes - except spellcasters - get weapons skills as high as Warriors. This PR gives Warriors a small all-around buff, and gives them the option to use speed instead of strength primarily - For duelist or dervish types - and now will have the highest weapon skill of any adventurers, getting a 3 in Mace/Axes or Swords and Knifes, depending on subclass.

This won't make them feel significantly stronger than other Adventurers, but does at least make them capable of giving others some training and have something special to them.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
