### PR TITLE
fixes zombie npc aggro

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -124,6 +124,8 @@
 			if(!was_i_undead)
 				zombie.mob_biotypes &= ~MOB_UNDEAD
 			zombie.faction -= "undead"
+			zombie.faction += "station"
+			zombie.faction += "neutral"
 			zombie.regenerate_organs()
 			if(has_turned)
 				to_chat(zombie, "<span class='green'>I no longer crave for flesh...</span>")
@@ -173,6 +175,8 @@
 		zombie.charflaw.ephemeral = TRUE
 	zombie.mob_biotypes |= MOB_UNDEAD
 	zombie.faction += "undead"
+	zombie.faction -= "station"
+	zombie.faction -= "neutral"
 	zombie.verbs |= /mob/living/carbon/human/proc/zombie_seek
 	for(var/obj/item/bodypart/zombie_part as anything in zombie.bodyparts)
 		if(!zombie_part.rotted && !zombie_part.skeletonized)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -247,7 +247,7 @@
 	if(enemies[L])
 		return TRUE
 
-	if(aggressive && !faction_check_mob(L) && !mind?.has_antag_datum(/datum/antagonist/zombie))
+	if(aggressive && !faction_check_mob(L))
 		return TRUE
 
 	return FALSE
@@ -270,7 +270,7 @@
 				m_intent = MOVE_INTENT_WALK
 				INVOKE_ASYNC(src, PROC_REF(walk2derpless), target)
 
-			if(!get_active_held_item() && !get_inactive_held_item())
+			if(!get_active_held_item() && !get_inactive_held_item() && !mind?.has_antag_datum(/datum/antagonist/zombie))
 				// pickup any nearby weapon
 				for(var/obj/item/I in view(1,src))
 					if(!isturf(I.loc))

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -247,7 +247,7 @@
 	if(enemies[L])
 		return TRUE
 
-	if(aggressive && !faction_check_mob(L))
+	if(aggressive && !faction_check_mob(L) && !mind?.has_antag_datum(/datum/antagonist/zombie))
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

makes zombies aggro by removing their factions. also adds them back when they lose zombie antag.

additionally adds a check to npc's equipping items to make sure they aren't zombies. because zombies are dumb and also can't hit things with a weapon.

## Why It's Good For The Game

zombie npcs work now