### PR TITLE
Doubles saigabuck HP

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
@@ -37,7 +37,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/taming, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/butchering, 5, TRUE)
 	if(H.gender == MALE)

--- a/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
@@ -192,8 +192,8 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	attack_verb_continuous = "headbutts"
 	attack_verb_simple = "headbutt"
-	health = 200
-	maxHealth = 200
+	health = 400
+	maxHealth = 400
 	melee_damage_lower = 60
 	melee_damage_upper = 90
 	environment_smash = ENVIRONMENT_SMASH_NONE


### PR DESCRIPTION
## About The Pull Request

Doubles saigabuck HP from 200 to 400.

## Why It's Good For The Game

Currently, if a saiga loses 25% of its max hp it becomes crippled, losing 50% of its movespeed, making it basically useless until healed by a cleric. There is no mundane way of healing them that I have found, and I cannot find where to change the threshold for this effect. You cannot even feed them healing potions. So, this is a (temporary?) cope-work-around to make male saigas more viable war mounts by improving their HP pool, and as an effect, also doubling the amount of damage for this cripple to take effect to 100 damage.

Saigabucks are a bit rare to breed (30%) and even rarer to find with bait too, so improving their survivability with them being huge mean alpha studs built to protect the herd seems reasonable as well. The female saigas will remain an archers obvious economic choice, as opposed to a wannabe knight requiring a rarer, more expensive male one. And finally, this will hopefully make the butcher a more notable member of the town.