### PR TITLE
Removes night vision from elves

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -139,14 +139,10 @@
 /obj/item/organ/eyes/elf
 	name = "elf eyes"
 	desc = ""
-	see_in_dark = 4
-	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 
 /obj/item/organ/eyes/halfelf
 	name = "half-elf eyes"
 	desc = ""
-	see_in_dark = 3
-	lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
 
 /obj/item/organ/eyes/goblin
 	name = "goblin eyes"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes elves ability to have night vision. Balance. One race having night vision for free over every other race is lame. Left in the actual muttrait that gives elf eyes so if someone wants to ever reintroduce it for whatever godawful reason they can. I tested it and it worked.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes it so everyone is afraid of the dark equally. Even elves should benefit from darkness. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Maybe put up a poll on discord for a day or something if it is that controversial of a change.