### PR TITLE
Makes dwarves have a seperate liver.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
@@ -5,6 +5,7 @@
 	name = "Dwarfb"
 	id = "dwarf"
 	max_age = 200
+	mutantliver = /obj/item/organ/liver/dwarf
 
 /datum/species/dwarf/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -102,3 +102,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	damage += 100/severity
+
+/obj/item/organ/liver/dwarf
+	name = "dwarf liver"
+	desc = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I was trying to add drunken healing to the dwarf liver itself as apparently the quirk doesn't work. I could not figure out how to do it but i did make it so that dwarf liver is actually listed as such and is a mutant organ like elf eyes so that if someone wishes to add the drunken healing they may.
## Why It's Good For The Game
Lets someone skip a step when adding back drunken healing to the angry midget people.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
