### PR TITLE
the DEhuddening- Rebels

### DIFF
--- a/code/modules/antagonists/roguetown/villain/peasantrebel.dm
+++ b/code/modules/antagonists/roguetown/villain/peasantrebel.dm
@@ -51,14 +51,6 @@
 		if(new_owner.current && HAS_TRAIT(new_owner.current, TRAIT_MINDSHIELD))
 			return FALSE
 
-/datum/antagonist/prebel/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/prebel/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
-
 /datum/antagonist/prebel/on_gain()
 	. = ..()
 	create_objectives()


### PR DESCRIPTION
## About The Pull Request

Rebels no longer have a HUD telling them who other rebels are, though they can still examine to see their allies

## Why It's Good For The Game

pretty sure the maintainers wanted it, and so I might as well do it since it took me about 2 minutes to do. Might wanna TM first to see if rebel players will riot against coders