### PR TITLE
Fast Reflexes stamina drain nerf

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -376,8 +376,8 @@
 			if(!H?.check_armor_skill())
 				H.Knockdown(1)
 				return FALSE
-			if(H?.check_dodge_skill())
-				drained = drained - 5
+//			if(H?.check_dodge_skill())
+//				drained = drained - 5  commented out for being too much. It was giving effectively double stamina efficiency compared to everyone else.
 //			if(H.mind)
 //				drained = drained + max((H.checkwornweight() * 10)-(mind.get_skill_level(/datum/skill/misc/athletics) * 10),0)
 //			else


### PR DESCRIPTION
## About The Pull Request

Comments out the stamina drain halving for fast reflexes.

## Why It's Good For The Game

People with this trait had double the stamina bar compared to everyone else due to this, which resulted in comical situations. It's bad enough that the right race/class combo gives you 99% dodge rolls even against expert warriors, but they can outlast you too.

I also found out dodging works even if someone is attacking you from behind. At least, that's what happened testing with an angry skeleton locally. So, it's already got a huge edge over parrying from that alone.
