### PR TITLE
Doubles heavy helm integrity and adds smash protection

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -489,9 +489,10 @@
 	flags_inv = HIDEEARS|HIDEFACE
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
+	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST)
 	block2add = FOV_RIGHT|FOV_LEFT
 	smeltresult = /obj/item/ingot/steel
+	max_integrity = 400
 
 /obj/item/clothing/head/roguetown/helmet/heavy/guard
 	name = "savoyard"


### PR DESCRIPTION
## About The Pull Request

Changes heavy helmet integrity to 400
Adds smash critical hit protection

## Why It's Good For The Game

These helmets cost 2 bars and completely fuck your FOV (you can only parry the guy right in front of you).
Everyone pretty much agrees they're worthless compared to just helmet + mask, which is collectively double the integrity without nearly the downsides.

This is also going to be the **only** helmet line that will protect you from being knocked out by shit like flails. Heavy helmets finally have an actual use case compared to alternatives.
