### PR TITLE
Athletic Skill Buff and XP gain

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/desertrider.dm
@@ -64,6 +64,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.change_stat("strength", 2)
 		H.change_stat("endurance", 3)
 		H.change_stat("constitution", 2)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/grenzelhoft.dm
@@ -62,6 +62,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.change_stat("strength", 3)
 		H.change_stat("endurance", 2)
 		H.change_stat("constitution", 3)

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -16,7 +16,7 @@
 	update_health_hud()
 
 /mob/living/proc/update_rogstam()
-		var/athletics_skill = 0
+	var/athletics_skill = 0
 	if(mind)
 		athletics_skill = mind.get_skill_level(/datum/skill/misc/athletics)
 	maxrogstam = (STAEND + (athletics_skill/2 ) ) * 100

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -16,7 +16,10 @@
 	update_health_hud()
 
 /mob/living/proc/update_rogstam()
-	maxrogstam = STAEND * 100
+		var/athletics_skill = 0
+	if(mind)
+		athletics_skill = mind.get_skill_level(/datum/skill/misc/athletics)
+	maxrogstam = (STAEND + (athletics_skill/2 ) ) * 100
 	if(cmode)
 		if(!HAS_TRAIT(src, TRAIT_BREADY))
 			rogstam_add(-2)
@@ -27,6 +30,8 @@
 /mob/living/rogstam_add(added as num)
 	if(HAS_TRAIT(src, TRAIT_NOROGSTAM))
 		return TRUE
+	if(m_intent == MOVE_INTENT_RUN)
+		mind.adjust_experience(/datum/skill/misc/athletics, (STAINT*0.02))
 	rogstam += added
 	if(rogstam > maxrogstam)
 		rogstam = maxrogstam


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Everytime someone run and lose stamina they gain abit of athletic xp based off their int, the max stam was based of only endurance  but now athletic also counts towards it, the skill level divided by 2 would be basically one single stat of endurance.

- Example : Level 6 skill of Athletic (Legendary) , Base Stat Endurance : X, on the max stamina calculation their Endurance will be XIII.

 
## Why It's Good For The Game

Athletic  only had calculations for knockback and was not trainable, now this skill can increase your stamina and is trainable, ofcourse it is slow but it is possible to reach lvl 3-4 with like 20-30 min training non stopping with rest pauses.
Technically a trainable stat but you really just increase the skill.
