### PR TITLE
Removed allowed_race list from talkstones

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -211,7 +211,6 @@
 	item_state = "talkstone"
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
-	allowed_race = list("human", "dwarf", "elf", "tiefling", "aasimar", "goblinp", "halforc")
 	sellprice = 98
 	anvilrepair = /datum/skill/craft/armorsmithing
 


### PR DESCRIPTION
## About The Pull Request

Removing this list lets you equip it.

## Why It's Good For The Game

I assume this shit is deprecated since it wasn't working for any race in the list. Anyways just removing it let me equip it as expected locally.