### PR TITLE
PQ new deal part 1 of ?: Severely reduces mechanical PQ gain sources, you can no longer gain PQ from people you murdered

### DIFF
--- a/code/__DEFINES/playerquality.dm
+++ b/code/__DEFINES/playerquality.dm
@@ -1,0 +1,4 @@
+#define PQ_GAIN_BURIAL 0.1
+#define PQ_GAIN_BURIAL_COIN 0.05
+#define PQ_GAIN_REVIVE 0.1
+#define PQ_GAIN_UNZOMBIFY 0.1

--- a/code/modules/mob/living/carbon/spirit/spirit.dm
+++ b/code/modules/mob/living/carbon/spirit/spirit.dm
@@ -177,7 +177,7 @@
 	return src
 
 /// Proc that will search inside a given atom for any corpses, and send the associated ghost to the lobby if possible
-/proc/pacify_coffin(atom/movable/coffin, mob/user, deep = TRUE, give_pq = 0.2)
+/proc/pacify_coffin(atom/movable/coffin, mob/user, deep = TRUE, give_pq = PQ_GAIN_BURIAL)
 	if(!coffin)
 		return FALSE
 	var/success = FALSE
@@ -195,14 +195,16 @@
 			if(isliving(stuffing) || istype(stuffing, /obj/item/bodypart/head))
 				continue
 			success ||= pacify_coffin(stuffing, user, deep, give_pq = FALSE)
-	if(success && give_pq && user?.ckey)
+	// Success is actually the ckey of the last attacker so we can prevent PQ farming from fragging people
+	if(success && give_pq && user?.ckey && (user.ckey != success))
 		adjust_playerquality(give_pq, user.ckey)
 	return success
 
 /// Proc that sends the client associated with a given corpse to the lobby, if possible
-/proc/pacify_corpse(mob/living/corpse, mob/user, coin_pq = 0.2)
+/proc/pacify_corpse(mob/living/corpse, mob/user, coin_pq = PQ_GAIN_BURIAL_COIN)
 	if((corpse.stat != DEAD) || !corpse.mind)
 		return FALSE
+	var/attacker_ckey = corpse.lastattackerckey || TRUE
 	if(ishuman(corpse))
 		var/mob/living/carbon/human/human_corpse = corpse
 		human_corpse.buried = TRUE
@@ -240,7 +242,7 @@
 		var/user_acknowledgement = user ? user.real_name : "a mysterious force"
 		to_chat(ghost, "<span class='rose'>My soul finds peace buried in creation, thanks to [user_acknowledgement].</span>")
 		ghost.returntolobby(RESPAWNTIME*-1)
-		return TRUE
+		return attacker_ckey
 
 	testing("pacify_corpse fail ([corpse.mind?.key || "no key"])")
 	return FALSE

--- a/code/modules/mob/living/carbon/spirit/spirit.dm
+++ b/code/modules/mob/living/carbon/spirit/spirit.dm
@@ -218,7 +218,7 @@
 					fallen = locate(fallen.x + rand(-3, 3), fallen.y + rand(-3, 3), fallen.z)
 					new /obj/item/underworld/coin/notracking(fallen)
 					fallen.visible_message("<span class='warning'>A coin falls from above!</span>")
-					if(coin_pq && user?.ckey)
+					if(coin_pq && user?.ckey && (user.ckey != attacker_ckey))
 						adjust_playerquality(coin_pq, user.ckey)
 					qdel(human_corpse.mouth)
 					human_corpse.update_inv_mouth()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -59,7 +59,7 @@
 	miracle = TRUE
 	devotion_cost = -100
 	/// Amount of PQ gained for reviving people
-	var/revive_pq = 0.25
+	var/revive_pq = PQ_GAIN_REVIVE
 
 /obj/effect/proc_holder/spell/invoked/revive/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -143,7 +143,7 @@
 	miracle = TRUE
 	devotion_cost = -100
 	/// Amount of PQ gained for curing zombos
-	var/unzombification_pq = 0.4
+	var/unzombification_pq = PQ_GAIN_UNZOMBIFY
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -79,6 +79,7 @@
 #include "code\__DEFINES\omens.dm"
 #include "code\__DEFINES\pinpointers.dm"
 #include "code\__DEFINES\pipe_construction.dm"
+#include "code\__DEFINES\playerquality.dm"
 #include "code\__DEFINES\plumbing.dm"
 #include "code\__DEFINES\power.dm"
 #include "code\__DEFINES\preferences.dm"


### PR DESCRIPTION
## About The Pull Request

Title
It will take 10 burials to get 1 PQ.
It will take 7 burials with coin in mouth to get 1 PQ.
It will take 10 revivals to get 1 PQ.

## Why It's Good For The Game

PQ is inherently inflationary and for it to actually work we need to keep good track of every source and ensure it's not being handed out willy nilly. Time to combat the PQ inflation we are now suffering with.