### PR TITLE
miners n blacksmith FORTUNE PILLED???

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -63,3 +63,4 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("constitution", 2)
 		H.change_stat("speed", -1)
+		H.change_stat("fortune", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -63,4 +63,4 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("constitution", 2)
 		H.change_stat("speed", -1)
-		H.change_stat("fortune", 2)
+		H.change_stat("fortune", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -51,3 +51,4 @@
 		H.change_stat("intelligence", -1)
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 2)
+		H.change_stat("fortune", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -36,3 +36,5 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("constitution", 1)
 		H.change_stat("perception", 1)
+		H.change_stat("fortune", 3)
+

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -36,5 +36,5 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("constitution", 1)
 		H.change_stat("perception", 1)
-		H.change_stat("fortune", 3)
+		H.change_stat("fortune", 4)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
@@ -54,6 +54,8 @@
 				H.mind.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
 			H.change_stat("strength", 2)
 			H.change_stat("speed", -1)
+			H.change_stat("fortune", 3)
+
 
 	else
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
@@ -79,3 +81,4 @@
 				H.mind.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
 			H.change_stat("strength", 2)
 			H.change_stat("speed", -1)
+			H.change_stat("fortune", 3)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
@@ -54,7 +54,7 @@
 				H.mind.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
 			H.change_stat("strength", 2)
 			H.change_stat("speed", -1)
-			H.change_stat("fortune", 3)
+			H.change_stat("fortune", 2)
 
 
 	else


### PR DESCRIPTION
fortune-pills blacksmiths and miners since fortune affects mining and it's weird they don't get a buff to it. Hopefully it can incentivize actually going mining for once cause 9/10 times it appears that the Rockhill mine is empty, deserted and unused. (Im not calculing with dwarf fortresses here frfr thats diff man cmon) 

Makes mining a more viable job really and more likely fun as well since now you have a bigger chance to find gems and cool stuff! 
