### PR TITLE
Makes surgery tools craftable.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -125,6 +125,42 @@
 	created_item = /obj/item/rogueweapon/pick/steel
 	i_type = "Tools"
 
+/datum/anvil_recipe/tools/surgery/scalpel
+	name = "Scalpel"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/scalpel
+	i_type = "Tools"
+
+/datum/anvil_recipe/tools/surgery/saw
+	name = "Surgical Saw"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/saw
+	i_type = "Tools"
+
+/datum/anvil_recipe/tools/surgery/hemostat
+	name = "Forceps"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/hemostat
+	i_type = "Tools"
+
+/datum/anvil_recipe/tools/surgery/retractor
+	name = "Speculum"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/retractor
+	i_type = "Tools"
+
+/datum/anvil_recipe/tools/surgery/bonesetter
+	name = "Bone Forceps"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/bonesetter
+	i_type = "Tools"
+
+/datum/anvil_recipe/tools/surgery/cautery
+	name = "Cautery Iron"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/rogueweapon/surgery/cautery
+	i_type = "Tools"
+
 /datum/anvil_recipe/tools/cupssteel
 	name = "Goblets 3x"
 	req_bar = /obj/item/ingot/steel

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -79,7 +79,7 @@
 /datum/anvil_recipe/weapons/scutlass
 	name = "Cutlass"
 	req_bar = /obj/item/ingot/steel
-	created_item = /obj/item/rogueweapon/sword/cutlass
+	created_item = /cutlass
 	i_type = "Weapons"
 
 /datum/anvil_recipe/weapons/hknife

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -79,7 +79,7 @@
 /datum/anvil_recipe/weapons/scutlass
 	name = "Cutlass"
 	req_bar = /obj/item/ingot/steel
-	created_item = /cutlass
+	created_item = /obj/item/rogueweapon/sword/cutlass
 	i_type = "Weapons"
 
 /datum/anvil_recipe/weapons/hknife

--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -17,7 +17,7 @@
 	thrown_bclass = BCLASS_CUT
 	associated_skill = /datum/skill/combat/knives
 	anvilrepair = /datum/skill/craft/blacksmithing
-	smeltresult = /obj/item/ingot/iron
+	smeltresult = /obj/item/ingot/steel
 
 /obj/item/rogueweapon/surgery/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes surgical tools actually craftable, albeit expensive for a full set, so that having your set stolen doesn't immediately remove your ability to do your job for the rest of the round.

Yes, this is a salt PR, but I do believe it is good for the game.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The new surgery mechanics aren't that useful because, well, noone can really use them. The two roles that have tools can easily get them stolen too. This gives them an option to replace their tools or have spares on hand in case, well, something happens and they lose theirs. However, a full set of tools is hard enough to get that they shouldn't become common after this change: It takes a LOT of steel to make a full set.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
