### PR TITLE
Coif sanity

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -14,6 +14,7 @@
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD
 	armor = list("blunt" = 33, "slash" = 12, "stab" = 22, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	sewrepair = TRUE
@@ -83,9 +84,9 @@
 
 /obj/item/clothing/neck/roguetown/chaincoif/iron
 	icon_state = "ichaincoif"
-
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/iron
+	max_integrity = 150
 
 /obj/item/clothing/neck/roguetown/bervor
 	name = "bervor"


### PR DESCRIPTION
## About The Pull Request

The cloth coif was given cut and blunt critical hit protection.
Iron coifs lost 50 durability to differentiate them from steel.
Chain coifs lost twist resistance.

## Why It's Good For The Game

Cloth coifs are gambesons for the head. Makes sense to inherit them.
Iron coifs needed to be worse than the steel version and this is mostly consistent with the difference between bervor and gorget. Dropping it to 100 durability seemed too harsh.
Chain coifs being consistent with chain body armor lost their twist resistance.

Low effort balanceslop as usual. Bug fix next.