### PR TITLE
Remove skeleton nolimbdisable and weapon dupe

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -23,9 +23,6 @@
 /mob/living/carbon/human/species/skeleton/Initialize()
 	. = ..()
 	cut_overlays()
-	spawn(10)
-		after_creation()
-
 	addtimer(CALLBACK(src, PROC_REF(after_creation)), 10)
 
 /mob/living/carbon/human/species/skeleton/after_creation()
@@ -61,7 +58,6 @@
 	real_name = "skelelon"
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
-	ADD_TRAIT(src, TRAIT_NOLIMBDISABLE, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_EASYDISMEMBER, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request
Removes NOLIMBDISABLE trait for skeletons and removes duplicate equipment spawn.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crits now work against skeletons. No more weapon dupe. Wanted by former headdev Abraxas.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
