### PR TITLE
automatic merge conflict labeling

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,0 +1,13 @@
+name: 'Merge Conflict Detection'
+on:
+  push:
+    branches:
+      - main
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'Merge Conflict'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR adds in a GitHub action which will automatically run when a PR is created. This action checks the mergability of a PR, and if it is conflicted, will add the appropriate label.

## Why It's Good For The ~~Game~~ Codebase

Allows maints to easily see at a glance whice PRs are conflicted and which ones aren't
