### PR TITLE
Bow replacements for crossbows

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -98,7 +98,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)

--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -140,9 +140,9 @@
 			else
 				r_hand = /obj/item/rogueweapon/flail/peasantwarflail
 			H.change_stat("strength", 1)
-		if(10 to 12) // crossbow bandit
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltl = /obj/item/quiver/bolts
+		if(10 to 12) // ranged bandit
+			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+			beltl = /obj/item/quiver/arrows
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 			H.change_stat("perception", 3)
 		if(13 to 15) // spear bandit

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -75,8 +75,8 @@
 	beltr = /obj/item/rogueweapon/sword
 	backr = /obj/item/storage/backpack/rogue/satchel
 	if(is_crossbowman)
-		backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-		beltr = /obj/item/quiver/bolts //replaces sword
+		backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+		beltr = /obj/item/quiver/arrows //replaces sword
 	else
 		backl = null
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -47,9 +47,9 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/rogueweapon/mace/cudgel
-	beltr = /obj/item/quiver/bolts
+	beltr = /obj/item/quiver/arrows
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
 	backpack_contents = list(/obj/item/keyring/gatemaster = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 6, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -52,7 +52,7 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
 	backpack_contents = list(/obj/item/keyring/gatemaster = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 6, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -75,8 +75,8 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/rope/chain = 1)
 	if(is_bowman)
-		backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-		beltr = /obj/item/quiver/bolts //replaces mace
+		backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+		beltr = /obj/item/quiver/arrows //replaces mace
 	else
 		backl = null
 	if(H.mind)


### PR DESCRIPTION
## About The Pull Request

All ranged roles except for dwarf ranger spawn with bows instead of crossbows now. They keep their skills in both.

## Why It's Good For The Game

This was supposed to be done forever ago when we mapped in crossbows.
