### PR TITLE
Fix sewage not making noise when you walk on it

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -119,11 +119,10 @@
 			if(water_level == 2)
 				L.SoakMob(BELOW_CHEST)
 		if(water_overlay)
-			if(water_level > 1)
-				if(istype(oldLoc, type))
-					playsound(AM, pick('sound/foley/watermove (1).ogg','sound/foley/watermove (2).ogg'), 100, FALSE)
-				else
-					playsound(AM, 'sound/foley/waterenter.ogg', 100, FALSE)
+			if(water_level > 1 && !istype(oldLoc, type))
+				playsound(AM, 'sound/foley/waterenter.ogg', 100, FALSE)
+			else
+				playsound(AM, pick('sound/foley/watermove (1).ogg','sound/foley/watermove (2).ogg'), 100, FALSE)
 			if(istype(oldLoc, type) && (get_dir(src, oldLoc) != SOUTH))
 				water_overlay.layer = ABOVE_MOB_LAYER
 				water_overlay.plane = GAME_PLANE_UPPER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes #1008 
Currently there is nothing that checks for when a player enters sewer water, this change simply adds that check and plays the appropriate sound for water movement. Since sewer water is shallow I omitted the splash sound effect on initial entry.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As stated in the issue players can run in water to completely mute themselves while being chased through the sewers which makes it much harder to track them given how dark it already is. Also everything should give some form of basic feedback to the player in some way.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
