### PR TITLE
Fix sprite alignment for Staff of the Shepherd

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -78,8 +78,8 @@
 	icon = 'icons/roguetown/weapons/32.dmi'
 	pixel_y = 0
 	pixel_x = 0
-	inhand_x_dimension = 32
-	inhand_y_dimension = 32
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
 	bigboy = FALSE
 	gripsprite = FALSE
 	gripped_intents = null
@@ -89,7 +89,7 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.6,"sx" = -6,"sy" = -1,"nx" = 8,"ny" = 0,"wx" = -4,"wy" = 0,"ex" = 2,"ey" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -38,"sturn" = 37,"wturn" = 32,"eturn" = -23,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+				return list("shrink" = 0.6,"sx" = -6,"sy" = 2,"nx" = 8,"ny" = 2,"wx" = -4,"wy" = 2,"ex" = 1,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -38,"sturn" = 300,"wturn" = 32,"eturn" = -23,"nflip" = 0,"sflip" = 100,"wflip" = 8,"eflip" = 0)
 			if("wielded")
 				return list("shrink" = 0.6,"sx" = 4,"sy" = -2,"nx" = -3,"ny" = -2,"wx" = -5,"wy" = -1,"ex" = 3,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 7,"sturn" = -7,"wturn" = 16,"eturn" = -22,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes misalignment with staff of the shepherd sprite while inhand.
![staff_of_the_shepherd](https://github.com/Blackstone-SS13/BLACKSTONE/assets/171774177/64dfcb20-184c-4c42-a6e4-c3aa5e500a25)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Misaligned sprites break immersion.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
