### PR TITLE
Allow dwarves to see in the dark

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
@@ -5,6 +5,7 @@
 	name = "Dwarfb"
 	id = "dwarf"
 	max_age = 200
+	mutanteyes = /obj/item/organ/eyes/dwarf
 
 /datum/species/dwarf/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -16,7 +16,8 @@
 	the various challenges they face. Even if, in some irony: this behaviour \
 	leads the race towards technological advancement as they continue \
 	to improve their craft through powerful mechanization and forging \
-	Dwarves are hearty, but are not known for their speed or eyesight... \
+	Dwarves are hearty, but are not known for their speed... \
+	Life in darkness has acclimated their vision to see within it. \
 	Each dwarf hails from a ancient fortress named after the most plentiful mineral."
 
 	skin_tone_wording = "Dwarf Fortress"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -14,7 +14,7 @@
 	and tend to shun the modernization of the world around them. \
 	Instead, a Dwarf looks to his ancestorial heritage for guidance on \
 	the various challenges they face. Even if, in some irony: this behaviour \
-	leads the race towards technological advacement as they continue \
+	leads the race towards technological advancement as they continue \
 	to improve their craft through powerful mechanization and forging \
 	Dwarves are hearty, but are not known for their speed or eyesight... \
 	Each dwarf hails from a ancient fortress named after the most plentiful mineral."

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -142,6 +142,12 @@
 	name = "fung-eye"
 	desc = ""
 
+/obj/item/organ/eyes/dwarf
+	name = "dwarf eyes"
+	desc = ""
+	see_in_dark = 4
+	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+
 /obj/item/organ/eyes/elf
 	name = "elf eyes"
 	desc = ""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Closes #1113 
This change gives dwarves the same amount of night vision that elves currently have, as well as updating the description of dwarves to reflect that they can see in the dark instead of saying they have poor vision.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Doesn't make sense that fantasy dwarves, who spend their time in the dark, can't see in it at all. Also most depictions of dwarves have infravision.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
