### PR TITLE
Werewolves now get affect by the silver dagger and can't pick up it or the silver psycross

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -187,6 +187,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = user
 	var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
+	var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
 	if(ishuman(H))
 		if(H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
 			to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
@@ -199,6 +200,10 @@
 				to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
 				H.Knockdown(10)
 				H.Paralyze(10)
+		if(W && W.transformed == TRUE)
+			to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
+			H.Knockdown(20)
+			H.Paralyze(20)
 			
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
@@ -206,28 +211,34 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
+		var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
 		if(H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
+			to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
 			H.Knockdown(20)
 			H.adjustFireLoss(60)
 			H.Paralyze(20)
 			H.fire_act(1,5)
 		if(V_lord)
 			if(V_lord.vamplevel < 4 && !H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
+				to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
 				H.Knockdown(10)
 				H.Paralyze(10)
+		if(W && W.transformed == TRUE)
+			to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
+			H.Knockdown(20)
+			H.Paralyze(20)
 
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/funny_attack_effects(mob/living/target, mob/living/user = usr, nodmg)
 	if(world.time < src.last_used + 100)
 		to_chat(user, "<span class='notice'>The silver effect is on cooldown.</span>")
 		return
-	
-	
-	
+
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/s_user = user
 		var/mob/living/carbon/human/H = target
+		var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
 		var/datum/antagonist/vampirelord/lesser/V = H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser)
 		var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
 		if(V)
@@ -261,6 +272,10 @@
 				s_user.Paralyze(10)
 				to_chat(s_user, "<font color='red'> The silver weapon fails!</font>")
 				H.visible_message(H, "<span class='userdanger'>This feeble metal can't hurt me, I AM THE ANCIENT!</span>")
+		if(W && W.transformed == TRUE)
+			H.Stun(20)
+			H.Paralyze(20)
+			to_chat(H, "<span class='userdanger'>I'm hit by my BANE!</span>")
 
 
 /obj/item/rogueweapon/huntingknife/stoneknife

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -166,6 +166,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = user
 	var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
+	var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
 	if(ishuman(H))
 		if(H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
 			to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
@@ -178,24 +179,32 @@
 				to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
 				H.Knockdown(10)
 				H.Paralyze(10)
-			
+		if(W && W.transformed == TRUE)
+			to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
+			H.Knockdown(20)
+			H.Paralyze(20)	
 
 /obj/item/clothing/neck/roguetown/psicross/silver/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	. = ..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
+		var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
 		if(H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
-			to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
+			to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
 			H.Knockdown(20)
 			H.adjustFireLoss(60)
 			H.Paralyze(20)
 			H.fire_act(1,5)
 		if(V_lord)
 			if(V_lord.vamplevel < 4 && !H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser))
-				to_chat(H, "<span class='userdanger'>I can't pick up the silver, it is my BANE!</span>")
+				to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
 				H.Knockdown(10)
 				H.Paralyze(10)
+		if(W && W.transformed == TRUE)
+			to_chat(H, "<span class='userdanger'>I can't equip the silver, it is my BANE!</span>")
+			H.Knockdown(20)
+			H.Paralyze(20)
 
 /obj/item/clothing/neck/roguetown/psicross/g
 	name = "golden psycross"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Werewolves once they are transformed they can't pick up silver weapons nor the psycross, they also get stunned by the silver dagger but they won't burn unlike the vampires, they don't seem to be cursed by Astrata so the silver dagger won't trigger the burning unlike the vampires.

- Open for ideas if someone wants to suggest something, i also could not think of a psycross effect unless preventing infection but that would not make any sense since the vamp lord can  still convert you.


## Why It's Good For The Game

Werewolves banes is in the game, gives the inquisitor/witch hunters a weapon to chase and hunt them.
