### PR TITLE
Construction PR Part 2

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -292,7 +292,8 @@
 								atkswinging = null
 								//update_warning()
 								return
-//					resolveAdjacentClick(T,W,params,used_hand)
+					if(cmode)
+						resolveAdjacentClick(T,W,params,used_hand) //hit the turf
 					if(!used_intent.noaa)
 						changeNext_move(CLICK_CD_MELEE)
 						do_attack_animation(T, visual_effect_icon = used_intent.animname)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -51,9 +51,6 @@
 /obj/attackby(obj/item/I, mob/living/user, params)
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
 
-/turf/attackby(obj/item/I, mob/living/user, params)
-	return ..() || (max_integrity && I.attack_turf(src, user))
-
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())
 		return TRUE

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -194,18 +194,18 @@
 		for(var/obj/structure/S in T)
 			if(R.buildsame && istype(S, R.result))
 				if(user.dir == S.dir)
-					to_chat(user, span_warning("Something in the way."))
+					to_chat(user, span_warning("Something is in the way."))
 					return
 				continue
 			if(R.structurecraft && istype(S, R.structurecraft))
 				testing("isstructurecraft")
 				continue
 			if(S.density)
-				to_chat(user, span_warning("Something in the way."))
+				to_chat(user, span_warning("Something is in the way."))
 				return
 		for(var/obj/machinery/M in T)
 			if(M.density)
-				to_chat(user, span_warning("Something in the way."))
+				to_chat(user, span_warning("Something is in the way."))
 				return
 	if(R.req_table)
 		if(!(locate(/obj/structure/table) in T))

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -183,9 +183,6 @@
 	if(!R.TurfCheck(user, T))
 		to_chat(user, span_warning("I can't craft here."))
 		return
-	if(istype(T, /turf/open/water))
-		to_chat(user, span_warning("I can't craft here."))
-		return
 	if(isturf(R.result))
 		for(var/obj/structure/fluff/traveltile/TT in range(7, user))
 			to_chat(user, span_warning("I can't craft here."))

--- a/code/game/objects/items/rogueitems/bells.dm
+++ b/code/game/objects/items/rogueitems/bells.dm
@@ -23,7 +23,7 @@
 
 	for(var/mob/M in view(10, src.loc))
 		if(M.client)
-			to_chat(M, span_notice("BELL RINGS"))
+			to_chat(M, span_notice("The handheld bell rings sharply through the area."))
 
 	user.visible_message(span_notice("[user] rings [src]."))
 	ringing = TRUE

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -762,6 +762,10 @@
 	max_integrity = 300
 	dir = SOUTH
 
+/obj/structure/fluff/statue/OnCrafted(dirin, user)
+	dirin = turn(dirin, 180)
+	. = ..()
+
 /obj/structure/fluff/statue/attack_right(mob/user)
 	if(user.mind && isliving(user))
 		if(user.mind.special_items && user.mind.special_items.len)
@@ -1033,6 +1037,7 @@
 /obj/structure/fluff/psycross/crafted
 	name = "wooden pantheon cross"
 	icon_state = "psycrosscrafted"
+	max_integrity = 80
 	chance2hear = 10
 
 /obj/structure/fluff/psycross/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -677,7 +677,7 @@
 		to_chat(user, span_warning("The door doesn't lock from this side."))
 
 /obj/structure/mineral_door/wood/donjon
-	desc = ""
+	desc = "dungeon door"
 	icon_state = "donjondir"
 	base_state = "donjon"
 	keylock = TRUE
@@ -691,11 +691,11 @@
 	attacked_sound = list("sound/combat/hits/onmetal/metalimpact (1).ogg", "sound/combat/hits/onmetal/metalimpact (2).ogg")
 
 /obj/structure/mineral_door/wood/donjon/stone
-	desc = ""
+	desc = "stone door"
 	icon_state = "stone"
 	base_state = "stone"
 	keylock = TRUE
-	max_integrity = 1000
+	max_integrity = 1500
 	over_state = "stoneopen"
 	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 
@@ -742,7 +742,7 @@
 	openSound = 'sound/foley/doors/ironopen.ogg'
 	closeSound = 'sound/foley/doors/ironclose.ogg'
 	resistance_flags = null
-	max_integrity = 1000
+	max_integrity = 2000
 	damage_deflection = 15
 	layer = ABOVE_MOB_LAYER
 	keylock = TRUE

--- a/code/game/objects/structures/walldeco.dm
+++ b/code/game/objects/structures/walldeco.dm
@@ -8,6 +8,20 @@
 	max_integrity = 0
 	layer = ABOVE_MOB_LAYER+0.1
 
+/obj/structure/fluff/walldeco/OnCrafted(dirin, user)
+	pixel_x = 0
+	pixel_y = 0
+	switch(dirin)
+		if(NORTH)
+			pixel_y = 32
+		if(SOUTH)
+			pixel_y = -32
+		if(EAST)
+			pixel_x = 32
+		if(WEST)
+			pixel_x = -32
+	. = ..()
+
 /obj/structure/fluff/walldeco/proc/get_attached_wall()
 	return
 

--- a/code/game/turfs/closed/wall/roguewalls.dm
+++ b/code/game/turfs/closed/wall/roguewalls.dm
@@ -37,7 +37,7 @@
 	name = "stone window"
 	desc = "A window with solid and sturdy stone frame."
 	opacity = FALSE
-	max_integrity = 900
+	max_integrity = 1300
 
 /turf/closed/wall/mineral/rogue/stone/window/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && ((mover.pass_flags & PASSTABLE) || (mover.pass_flags & PASSGRILLE)) )
@@ -60,7 +60,7 @@
 
 /turf/closed/wall/mineral/rogue/craftstone
 	name = "stone wall"
-	desc = "A wall of unyielding, smooth stone."
+	desc = "A durable wall made from specially crafted stone."
 	icon = 'icons/turf/walls/craftstone.dmi'
 	icon_state = "box"
 	smooth = SMOOTH_MORE
@@ -178,7 +178,7 @@
 	name = "dark wood window"
 	icon_state = "subwindow"
 	opacity = FALSE
-	max_integrity = 550
+	max_integrity = 850
 
 /turf/closed/wall/mineral/rogue/wooddark/window/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && ((mover.pass_flags & PASSTABLE) || (mover.pass_flags & PASSGRILLE)) )

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -12,6 +12,8 @@
 	var/footstepstealth = FALSE
 	baseturfs = /turf/open/transparent/openspace
 
+	damage_deflection = INFINITY //TODO: Find a better method for breakable turf system
+
 /turf/proc/get_slowdown(mob/user)
 	return 0
 

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -43,6 +43,17 @@
 /turf/open/floor/rogue/ruinedwood/chevron
 	icon_state = "weird2"
 
+/turf/open/floor/rogue/ruinedwood/platform
+	name = "platform"
+	desc = "A destructible platform."
+	damage_deflection = 8
+	break_sound = 'sound/combat/hits/onwood/destroywalldoor.ogg'
+	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
+
+/turf/open/floor/rogue/ruinedwood/platform/turf_destruction(damage_flag)
+	. = ..()
+	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+
 /turf/open/floor/rogue/twig
 	icon_state = "twig"
 	footstep = FOOTSTEP_GRASS
@@ -55,6 +66,18 @@
 /turf/open/floor/rogue/twig/Initialize()
 	dir = pick(GLOB.cardinals)
 	. = ..()
+
+/turf/open/floor/rogue/twig/platform
+	name = "platform"
+	desc = "A destructible platform."
+	damage_deflection = 6
+	max_integrity = 200
+	break_sound = 'sound/combat/hits/onwood/destroywalldoor.ogg'
+	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
+
+/turf/open/floor/rogue/twig/platform/turf_destruction(damage_flag)
+	. = ..()
+	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
 /turf/open/floor/rogue/wood
 	smooth_icon = 'icons/turf/floors/wood.dmi'
@@ -453,6 +476,18 @@
 	icon_state = "paving"
 /turf/open/floor/rogue/blocks/paving/vert
 	icon_state = "paving-t"
+
+/turf/open/floor/rogue/blocks/platform
+	name = "platform"
+	desc = "A destructible platform."
+	damage_deflection = 10
+	max_integrity = 800
+	break_sound = 'sound/combat/hits/onstone/stonedeath.ogg'
+	attacked_sound = list('sound/combat/hits/onstone/wallhit.ogg', 'sound/combat/hits/onstone/wallhit2.ogg', 'sound/combat/hits/onstone/wallhit3.ogg')
+
+/turf/open/floor/rogue/blocks/platform/turf_destruction(damage_flag)
+	. = ..()
+	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
 /turf/open/floor/rogue/greenstone
 	icon_state = "greenstone"

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -19,7 +19,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open/transparent/openspace
 	name = "open space"
-	desc = "My eyes can see far down below.."
+	desc = "My eyes can see far down below."
 	icon_state = "openspace"
 	baseturfs = /turf/open/transparent/openspace
 	CanAtmosPassVertical = ATMOS_PASS_YES

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -297,6 +297,7 @@
 /turf/attackby(obj/item/C, mob/user, params)
 	if(..())
 		return TRUE
+	//Cables and RCD
 	if(can_lay_cable() && istype(C, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/coil = C
 		coil.place_turf(src, user)
@@ -313,7 +314,7 @@
 	else if(istype(C, /obj/item/twohanded/rcl))
 		handleRCL(C, user)
 
-	return FALSE
+	return max_integrity && C.attack_turf(src, user)
 
 /turf/CanPass(atom/movable/mover, turf/target)
 	if(!target)

--- a/code/modules/power/roguelighting.dm
+++ b/code/modules/power/roguelighting.dm
@@ -453,6 +453,20 @@
 	pixel_y = 32
 	soundloop = null
 
+/obj/machinery/light/rogue/wallfire/candle/OnCrafted(dirin, user)
+	pixel_x = 0
+	pixel_y = 0
+	switch(dirin)
+		if(NORTH)
+			pixel_y = 32
+		if(SOUTH)
+			pixel_y = -32
+		if(EAST)
+			pixel_x = 32
+		if(WEST)
+			pixel_x = -32
+	. = ..()
+	
 /obj/machinery/light/rogue/wallfire/candle/attack_hand(mob/user)
 	if(isliving(user) && on)
 		user.visible_message(span_warning("[user] snuffs [src]."))
@@ -523,7 +537,7 @@
 /obj/machinery/light/rogue/torchholder/OnCrafted(dirin, user)
 	if(dirin == NORTH)
 		pixel_y = 32
-	dirin = angle2dir(dir2angle(dirin) + 180)
+	dirin = turn(dirin, 180)
 	QDEL_NULL(torchy)
 	on = FALSE
 	set_light(0)

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -91,8 +91,10 @@
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/candle
-	name = "candle"
-	result = /obj/item/candle/yellow
+	name = "candle (x3)"
+	result = list(/obj/item/candle/yellow,
+				/obj/item/candle/yellow,
+				/obj/item/candle/yellow)
 	reqs = list(/obj/item/reagent_containers/food/snacks/fat = 2)
 
 /datum/crafting_recipe/roguetown/stoneaxe
@@ -125,6 +127,7 @@
 	name = "improvised billhook"
 	result = /obj/item/rogueweapon/spear/improvisedbillhook
 	reqs = list(/obj/item/rogueweapon/sickle = 1,
+				/obj/item/rope = 1,
 				/obj/item/grown/log/tree/small = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3
@@ -133,6 +136,7 @@
 	name = "goedendag"
 	result = /obj/item/rogueweapon/mace/goden
 	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/rope = 1,
 				/obj/item/rogueweapon/hoe = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3
@@ -141,6 +145,7 @@
 	name = "peasant war flail"
 	result = /obj/item/rogueweapon/flail/peasantwarflail
 	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/rope = 1,
 				/obj/item/rogueweapon/thresher = 1)
 	tools = list(/obj/item/rogueweapon/hammer)
 	craftdiff = 3

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -250,7 +250,7 @@
 	sellprice = 80
 
 /datum/crafting_recipe/roguetown/sewing/sexydress
-	name = "sexy dress of legendary sewers"
+	name = "sexy dress of legendary sewists"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy)
 	reqs = list(/obj/item/natural/cloth = 6,
 				/obj/item/natural/fibers = 3)

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -464,7 +464,7 @@
 	result = /obj/structure/fluff/statue/tdummy
 	reqs = list(/obj/item/grown/log/tree/small = 1,
 				/obj/item/grown/log/tree/stick = 1,
-				/obj/item/rope = 1)
+				/obj/item/natural/fibers = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
 	skillcraft = /datum/skill/craft/carpentry

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -1,9 +1,12 @@
 
 /datum/crafting_recipe/roguetown/structure
 	req_table = FALSE
+	craftsound = 'sound/foley/Building-01.ogg'
 
 /datum/crafting_recipe/roguetown/structure/TurfCheck(mob/user, turf/T)
 	if(istype(T,/turf/open/transparent/openspace))
+		return FALSE
+	if(istype(T, /turf/open/water))
 		return FALSE
 	return ..()
 
@@ -14,7 +17,6 @@
 				/obj/item/rope = 1)
 	verbage_simple = "construct"			
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 
 /datum/crafting_recipe/roguetown/structure/psycrss
 	name = "wooden cross"
@@ -23,8 +25,13 @@
 				/obj/item/grown/log/tree/stake = 3)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
-	craftdiff = 0
+	
+/datum/crafting_recipe/roguetown/structure/stonepsycrss
+	name = "stone cross"
+	result = /obj/structure/fluff/psycross
+	reqs = list(/obj/item/natural/stone = 2)
+	verbage_simple = "construct"
+	verbage = "constructs"
 
 /datum/crafting_recipe/roguetown/structure/swing_door
 	name = "swing door"
@@ -32,7 +39,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 
 /datum/crafting_recipe/roguetown/structure/door
@@ -41,8 +47,15 @@
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
+
+/datum/crafting_recipe/roguetown/structure/stonedoor
+	name = "stone door"
+	result = /obj/structure/mineral_door/wood/donjon/stone
+	reqs = list(/obj/item/natural/stone = 2)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
 
 /datum/crafting_recipe/roguetown/structure/doorbolt
 	name = "wooden door (deadbolt)"
@@ -51,9 +64,17 @@
 				/obj/item/grown/log/tree/stick = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/structure/fancydoor
+	name = "fancy door"
+	result = /obj/structure/mineral_door/wood/fancywood
+	reqs = list(/obj/item/grown/log/tree/small = 2)
+	verbage_simple = "construct"
+	verbage = "constructs"
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/structure/barrel
 	name = "wooden barrel"
@@ -61,7 +82,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "make"
 	verbage = "makes"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 
 /obj/structure/fermenting_barrel/crafted
@@ -73,7 +93,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "make"
 	verbage = "makes"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 0
 
@@ -83,7 +102,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 
 /obj/item/chair/rogue/crafted
@@ -96,7 +114,6 @@
 	skillcraft = /datum/skill/craft/carpentry
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 
 /obj/item/chair/stool/bar/rogue/crafted
 	sellprice = 6
@@ -108,7 +125,6 @@
 	skillcraft = /datum/skill/craft/blacksmithing
 	verbage_simple = "forge"
 	verbage = "forges"
-	craftsound = 'sound/foley/Building-01.ogg'
 
 /datum/crafting_recipe/roguetown/structure/smelter
 	name = "ore furnace"
@@ -128,7 +144,7 @@
 	verbage_simple = "build"
 	verbage = "builds"
 	craftsound = null
-	craftdiff = 3
+	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/structure/forge
 	name = "forge"
@@ -157,7 +173,6 @@
 				/obj/item/natural/fibers = 2)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	craftdiff = 2
 /*
 /datum/crafting_recipe/roguetown/structure/stairs
@@ -197,7 +212,6 @@
 	craftdiff = 2
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	ontile = TRUE
 
 /datum/crafting_recipe/roguetown/structure/stairsd/TurfCheck(mob/user, turf/T)
@@ -228,7 +242,6 @@
 	craftdiff = 2
 	verbage_simple = "builds"
 	verbage = "builds"
-	craftsound = 'sound/foley/Building-01.ogg'
 	ontile = TRUE
 
 /datum/crafting_recipe/roguetown/structure/stonestairsd/TurfCheck(mob/user, turf/T)
@@ -258,7 +271,6 @@
 	ontile = TRUE
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	buildsame = TRUE
 
@@ -269,7 +281,6 @@
 	ontile = TRUE
 	verbage_simple = "set up"
 	verbage = "sets up"
-	craftsound = 'sound/foley/Building-01.ogg'
 	buildsame = TRUE
 
 /datum/crafting_recipe/roguetown/structure/fencealt
@@ -279,7 +290,6 @@
 	ontile = TRUE
 	verbage_simple = "set up"
 	verbage = "sets up"
-	craftsound = 'sound/foley/Building-01.ogg'
 	buildsame = TRUE
 
 /datum/crafting_recipe/roguetown/structure/rack
@@ -288,7 +298,6 @@
 	reqs = list(/obj/item/grown/log/tree/stick = 3)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/structure/chest
@@ -297,7 +306,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 0
 
@@ -311,7 +319,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 
 /obj/structure/closet/crate/roguecloset/crafted
@@ -349,6 +356,14 @@
 	verbage_simple = "assembles"
 	verbage = "assembles"
 
+/datum/crafting_recipe/roguetown/structure/standing
+	name = "standing fire"
+	result = /obj/machinery/light/rogue/firebowl/standing
+	reqs = list(/obj/item/natural/stone = 1,
+				/obj/item/rogueore/coal = 1)
+	verbage_simple = "construct"
+	verbage = "constructs"
+
 /datum/crafting_recipe/roguetown/structure/oven
 	name = "oven"
 	result = /obj/machinery/light/rogue/oven
@@ -356,7 +371,6 @@
 				/obj/item/natural/stone = 3)
 	verbage_simple = "build"
 	verbage = "builds"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/masonry
 	wallcraft = TRUE
 
@@ -366,7 +380,6 @@
 	reqs = list(/obj/item/grown/log/tree/stick = 3)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 
 /datum/crafting_recipe/roguetown/structure/bed
 	name = "bed"
@@ -375,7 +388,6 @@
 				/obj/item/natural/fibers = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 
 /datum/crafting_recipe/roguetown/structure/nicebed
 	name = "nice bed"
@@ -385,7 +397,6 @@
 	tools = list(/obj/item/needle)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 2
 
@@ -395,7 +406,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 
 /datum/crafting_recipe/roguetown/structure/stonetable
@@ -404,7 +414,6 @@
 	reqs = list(/obj/item/natural/stone = 1)
 	verbage_simple = "build"
 	verbage = "builds"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/masonry
 
 /datum/crafting_recipe/roguetown/structure/millstone
@@ -422,7 +431,6 @@
 	reqs = list(/obj/item/roguegear = 1)
 	verbage_simple = "engineer"
 	verbage = "engineers"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/engineering
 
 /datum/crafting_recipe/roguetown/structure/trapdoor
@@ -432,7 +440,6 @@
 					/obj/item/roguegear = 1)
 	verbage_simple = "engineer"
 	verbage = "engineers"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 2
 
@@ -449,17 +456,17 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/structure/dummy
 	name = "training dummy"
 	result = /obj/structure/fluff/statue/tdummy
-	reqs = list(/obj/item/grown/log/tree/small = 1)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/grown/log/tree/stick = 1,
+				/obj/item/rope = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 1
 
@@ -470,7 +477,6 @@
 					/obj/item/roguegear = 1)
 	verbage_simple = "engineer"
 	verbage = "engineers"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 2
 
@@ -489,7 +495,6 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/carpentry
 	wallcraft = TRUE
 	craftdiff = 2
@@ -500,7 +505,35 @@
 	reqs = list(/obj/item/natural/stone = 2)
 	verbage_simple = "build"
 	verbage = "builds"
-	craftsound = 'sound/foley/Building-01.ogg'
 	skillcraft = /datum/skill/craft/masonry
 	wallcraft = TRUE
 	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/structure/wallcandle
+	name = "wall candles"
+	result = /obj/machinery/light/rogue/wallfire/candle
+	reqs = list(/obj/item/natural/stone = 1, /obj/item/candle/yellow = 1)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
+	wallcraft = TRUE
+	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/structure/stonewalldeco
+	name = "stone wall decoration"
+	result = /obj/structure/fluff/walldeco/stone
+	reqs = list(/obj/item/natural/stone = 1)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
+	wallcraft = TRUE
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/structure/statue
+	name = "statue"
+	result = /obj/structure/fluff/statue/femalestatue //TODO: Add sculpting
+	reqs = list(/obj/item/natural/stone = 3)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
+	craftdiff = 3

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -1,4 +1,5 @@
 
+/// WOOD
 
 /datum/crafting_recipe/roguetown/turfs/woodfloor
 	name = "wooden floor"
@@ -13,7 +14,24 @@
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/floor/rogue))
-		if(!istype(T, /turf/open/transparent/openspace))
+		return
+	return TRUE
+
+/datum/crafting_recipe/roguetown/turfs/woodplatform
+	name = "wooden platform"
+	result = /turf/open/floor/rogue/ruinedwood/platform
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+				/obj/item/natural/fibers = 1)
+	skillcraft = /datum/skill/craft/carpentry
+	verbage_simple = "construct"
+	verbage = "constructs"
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/turfs/woodplatform/TurfCheck(mob/user, turf/T)
+	if(isclosedturf(T))
+		return
+	if(!istype(T, /turf/open/transparent/openspace))
+		if(!istype(T, /turf/open/water))
 			return
 	return TRUE
 
@@ -36,7 +54,7 @@
 /datum/crafting_recipe/roguetown/turfs/fancywwall
 	name = "fancy wooden wall"
 	result = /turf/closed/wall/mineral/rogue/decowood
-	reqs = list(/obj/item/grown/log/tree/small = 3)
+	reqs = list(/obj/item/grown/log/tree/small = 2)
 	skillcraft = /datum/skill/craft/carpentry
 	verbage_simple = "construct"
 	verbage = "constructs"
@@ -65,6 +83,8 @@
 		return
 	return TRUE
 
+/// STONE
+
 /datum/crafting_recipe/roguetown/turfs/stonefloor
 	name = "stone floor"
 	result = /turf/open/floor/rogue/blocks
@@ -78,7 +98,24 @@
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/floor/rogue))
-		if(!istype(T, /turf/open/transparent/openspace))
+		return
+	return TRUE
+
+/datum/crafting_recipe/roguetown/turfs/stoneplatform
+	name = "stone platform"
+	result = /turf/open/floor/rogue/blocks/platform
+	reqs = list(/obj/item/natural/stone = 1,
+				/obj/item/natural/fibers = 1)
+	skillcraft = /datum/skill/craft/masonry
+	verbage_simple = "build"
+	verbage = "builds"
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/turfs/stoneplatform/TurfCheck(mob/user, turf/T)
+	if(isclosedturf(T))
+		return
+	if(!istype(T, /turf/open/transparent/openspace))
+		if(!istype(T, /turf/open/water))
 			return
 	return TRUE
 
@@ -101,11 +138,27 @@
 /datum/crafting_recipe/roguetown/turfs/fancyswall
 	name = "fancy stone wall"
 	result = /turf/closed/wall/mineral/rogue/decostone
-	reqs = list(/obj/item/natural/stone = 3)
+	reqs = list(/obj/item/natural/stone = 2)
 	skillcraft = /datum/skill/craft/masonry
 	verbage_simple = "build"
 	verbage = "builds"
 	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/turfs/fancyswall/TurfCheck(mob/user, turf/T)
+	if(isclosedturf(T))
+		return
+	if(!istype(T, /turf/open/floor/rogue))
+		return
+	return TRUE
+
+/datum/crafting_recipe/roguetown/turfs/craftstone
+	name = "craftstone wall"
+	result = /turf/closed/wall/mineral/rogue/craftstone
+	reqs = list(/obj/item/natural/stone = 3)
+	skillcraft = /datum/skill/craft/masonry
+	verbage_simple = "build"
+	verbage = "builds"
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/turfs/fancyswall/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
@@ -145,9 +198,26 @@
 	if(isclosedturf(T))
 		return
 	if(!istype(T, /turf/open/floor/rogue/dirt))
-		if(!istype(T, /turf/open/transparent/openspace))
-			if(!istype(T, /turf/open/floor/rogue/grass))
-				return
+		if(!istype(T, /turf/open/floor/rogue/grass))
+			return
+	return TRUE
+
+/datum/crafting_recipe/roguetown/turfs/twigplatform
+	name = "twig platform"
+	result = /turf/open/floor/rogue/twig/platform
+	reqs = list(/obj/item/grown/log/tree/stick = 2,
+				/obj/item/natural/fibers = 1)
+	skillcraft = /datum/skill/craft/crafting
+	verbage_simple = "assemble"
+	verbage = "assembles"
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/turfs/twigplatform/TurfCheck(mob/user, turf/T)
+	if(isclosedturf(T))
+		return
+	if(!istype(T, /turf/open/transparent/openspace))
+		if(!istype(T, /turf/open/water))
+			return
 	return TRUE
 
 /datum/crafting_recipe/roguetown/turfs/tentwall

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -205,8 +205,7 @@
 /datum/crafting_recipe/roguetown/turfs/twigplatform
 	name = "twig platform"
 	result = /turf/open/floor/rogue/twig/platform
-	reqs = list(/obj/item/grown/log/tree/stick = 2,
-				/obj/item/natural/fibers = 1)
+	reqs = list(/obj/item/grown/log/tree/stick = 3)
 	skillcraft = /datum/skill/craft/crafting
 	verbage_simple = "assemble"
 	verbage = "assembles"

--- a/code/modules/roguetown/roguejobs/cook/tools/oven.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/oven.dm
@@ -15,7 +15,8 @@
 	var/need_underlay_update = TRUE
 
 /obj/machinery/light/rogue/oven/OnCrafted(dirin)
-	dir = turn(dirin, 180)
+	dirin = turn(dirin, 180)
+	. = ..(dirin)
 	update_icon()
 
 /obj/machinery/light/rogue/oven/attackby(obj/item/W, mob/living/user, params)

--- a/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/gravemarker.dm
@@ -15,7 +15,7 @@
 		return FALSE
 	for(var/obj/structure/closet/dirthole/D in T)
 		if(D.stage != 4)
-			to_chat(user, span_warning("I can't."))
+			to_chat(user, span_warning("The grave isn't covered."))
 			return FALSE
 	if(locate(/obj/structure/gravemarker) in T)
 		to_chat(user, span_warning("This grave is already hallowed."))

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -1,7 +1,7 @@
 
 /obj/structure/closet/dirthole
 	name = "hole"
-	desc = "Just a small hole.."
+	desc = "Just a small hole..."
 	icon_state = "hole1"
 	icon = 'icons/turf/roguefloor.dmi'
 	var/stage = 1
@@ -19,7 +19,7 @@
 	layer = 2.8
 
 /obj/structure/closet/dirthole/grave
-	desc = "A hole big enough for a coffin.."
+	desc = "A hole big enough for a coffin."
 	stage = 3
 	faildirt = 3
 	icon_state = "grave"
@@ -162,7 +162,7 @@
 
 /atom/movable/screen/alert/status_effect/debuff/cursed
 	name = "Cursed"
-	desc = "I feel.. Unlucky."
+	desc = "I feel... unlucky."
 	icon_state = "debuff"
 
 /obj/structure/closet/dirthole/MouseDrop_T(atom/movable/O, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Changes the following recipes:
- Training Dummy: One log, one stick, *one fiber*
- Improvised billhook, goedendag, peasant war flail: Require an additional rope
- Candle: Now makes 3 candles when crafted
- Fancy wood and stone walls cost one less respective resource
- Great furnace difficulty reduced back to Apprentice

Adds the following recipes:
- Fancy wooden door - 2 wood; Carpentry; Journeyman
- Craftstone walls - 3 stone; Masonry; Expert
- Stone doors - 2 stone; Masonry; Novice
- Stone psycross - 2 stone; Crafting; Novice
- Standing fires - 1 stone, 1 coal; Crafting; Novice
- Wall candles - 1 stone, 1 candle; Masonry; None; Built on walls
- Stone wall decoration - 1 stone; Masonry; Apprentice; Built on walls
- Statue (only one type for now) - 3 stone; Masonry; Journeyman

Floors can no longer be built over openspaces. This functionality is taken over by "platforms", which cost an additional fiber and require Novice skill. *Twig platforms will require an additional stick instead.* Platforms can be built over both openspace and water turfs, and are **destructible with combat mode**.

Code
- Removes duplicate attackby proc for turfs
- More max_integrity balancing slop
- More text changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More construction good. As before please yell at me if balancing is bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
