### PR TITLE
Unshrinks your polearms

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -116,7 +116,6 @@
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/polearms
-	dropshrink = 0.6
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
 	wdefense = 5
@@ -170,7 +169,6 @@
 	max_blade_int = 50
 	smeltresult = null
 	associated_skill = /datum/skill/combat/polearms
-	dropshrink = 0.6
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
 	wdefense = 4
@@ -199,7 +197,6 @@
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/polearms
-	dropshrink = 0.6
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
 	wdefense = 6
@@ -250,7 +247,6 @@
 	minstr = 11
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/polearms
-	dropshrink = 0.6
 	blade_dulling = DULLING_BASHCHOP
 	walking_stick = TRUE
 	wdefense = 6
@@ -303,7 +299,6 @@
 	minstr = 9
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords
-	dropshrink = 0.6
 	max_blade_int = 300
 	wdefense = 5
 


### PR DESCRIPTION
## About The Pull Request

Removes dropshrink on the polearms that had it.

## Why It's Good For The Game

For some reason they're the only weapons getting their sprite shrunk when dropped. Considering they're largely thin sticks you pretty much have 1 pixel you have to perfectly click to pick them up too.