### PR TITLE
adds dark elf to seamstress so delf males can be it later lol

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
@@ -6,6 +6,7 @@
 		"Elf",
 		"Half-Elf",
 		"Dwarf",
+		"Dark Elf",
 	)
 	outfit = /datum/outfit/job/roguetown/adventurer/seamstress
 	isvillager = TRUE


### PR DESCRIPTION
For whenever the gender defines work, cause I think that will be hilarious

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds dork elf to seamstress
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So we can laugh about male dark elf seamstresses whine about being mistaken for a woman (they are literally the women of the race lol)

Also once this works that means female dark elf will be allowed to be doctor, and male will be seamstress (very funny)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
