### PR TITLE
Increases force when wielded from 20-30 for iron mace

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -1,6 +1,6 @@
 /obj/item/rogueweapon/mace
 	force = 20
-	force_wielded = 20
+	force_wielded = 30
 	possible_item_intents = list(/datum/intent/mace/strike)
 	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash)
 	name = "mace"


### PR DESCRIPTION
## About The Pull Request

force_wielded is changed from 20 to 30

## Why It's Good For The Game

Why does the steel mace get a damage increase from being 2 handed but not the iron variant? Not to mention all the other weapons.
It's just a clear inconsistency. Blunt is one of the worse damage types as well, given leather clothes/boots has quite high resists to it compared to others. No wonder everyone thinks this iron mace sucks ass. Because it does.