### PR TITLE
Adds devotion cost to kneestinger conjuration

### DIFF
--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -63,9 +63,9 @@
 	cast_without_targets = TRUE
 	sound = 'sound/items/dig_shovel.ogg'
 	associated_skill = /datum/skill/magic/holy
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	invocation = "Treefather light the way."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
+	devotion_cost = 75
 
 /obj/effect/proc_holder/spell/targeted/conjure_glowshroom/cast(list/targets, mob/user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds 75 devotion cost to kneestinger spell for dendor acolytes/druids.

## Why It's Good For The Game

Everything else has a cost but this. And since it's a t3 holy spell the cost is appropriate.
I really can't tell what's wrong, but I noticed all of dendor's spells besides the lesser miracle drain no stamina when cast. I suspect the other spells might suffer the same bug.