### PR TITLE
Zombies get no love from Xylix

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -51,6 +51,7 @@
 #define TRAIT_IWASHAUNTED "iwashaunted" //prevents spawning a haunt from a decapitated body twice
 #define TRAIT_SCHIZO_AMBIENCE "schizo_ambience" //replaces all ambience with creepy shit
 #define TRAIT_SCREENSHAKE "screenshake" //screen will always be shaking, you cannot stop it
+#define TRAIT_RAISEDEAD "Necromancer's Binding"
 
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WEBWALK = "I can move freely between webs.",
@@ -90,6 +91,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SHOCKIMMUNE = "I am immune to electrical shocks.",
 	TRAIT_NOSLEEP = "<span class='warning'>I can't sleep.</span>",
 	TRAIT_NOFALLDAMAGE1 = "<span class='warning'>I can easily handle minor falls.</span>",
+	TRAIT_RAISEDEAD = "I serve a Necromancer, whose power strengthens me and protects me from misfortune."
 ))
 
 // trait accessor defines

--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -194,6 +194,13 @@
 	zombie.STASPD = rand(5,7)
 
 	zombie.STAINT = 1
+	if(istype(zombie.patron, /datum/patron/inhumen/zizo))//Becoming a zombie comes with a punishment, lessened for worshippers of Zizo; Xylix hates the undead every bit as much as the rest of the Nine, and withholds his gifts from them.
+		zombie.STALUC = 5
+	if(HAS_TRAIT(zombie, TRAIT_RAISEDEAD))//Only the power of Zizo's faithful necromancers counteracts the curses of Xylix.
+		zombie.STALUC = 10
+		zombie.STASTR = 18
+	else
+		zombie.STALUC = -1
 	last_bite = world.time
 	has_turned = TRUE
 	// Drop your helm and gorgies boy you won't need it anymore!!!
@@ -328,7 +335,7 @@
 	if(!zombie_antag)
 		return
 	if(stat >= DEAD) //do shit the natural way i guess
-		return 
+		return
 	to_chat(src, "<span class='danger'>I feel horrible... REALLY horrible...</span>")
 	mob_timers["puke"] = world.time
 	vomit(1, blood = TRUE, stun = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Recently, playable zombies were re-added, and it has resulted in a trend of people intentionally becoming zombies and subsequently using weapons and shields to go on low-risk murder sprees, whether because of boredom, because they simply want to be someone else's problem, or because they didn't roll the classes/antag they wanted.

Since players have been irresponsible with this recently returned toy and also to pave the way for re-implementing necromancer as an antag, I propose the following in order to discourage self-zombifying:

- When a player becomes a zombie, if their character's patron is anything other than Zizo, their luck is reduced to 0. This means that aside from bite attacks, or attacks on the weak and unprepared, they will not be inflicting critical hits, and will find it very hard to successfully use weapons. Attacking in larger numbers should be your go-to.
- If the zombified player IS a worshipper of Zizo, their luck is reduced to 5 instead. This is to allow self-zombifying by people who worship necromancy to act like a sort of challenge class. 
- There is a new trait now, called TRAIT_RAISEDEAD, which will eventually be applied by Necromancers when they resurrect a corpse. A zombie created from a corpse with this trait will have their luck set to 10, which is average.
- When a zombie becomes a rotman via Pestra's clerics, their luck is restored to the average of 10
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zombies lately have been the most common and most deadly antagonists in a given round, and becoming a zombie is as easy as drowning yourself in some random murk where you won't be discovered and decapitated or buried before you can rot. Combine this with the capability to use weapons or shields with infinite stamina means that players can self-zombify and get to play wish.com vampires. This harsh luck reduction is intended to curtail such behavior and force zombies to rely on their natural weapons or other strategy besides swift attack spam if they aren't raised by powerful necromancers.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
