### PR TITLE
Papercrafting and reading training

### DIFF
--- a/code/game/objects/items/rogueitems/literary.dm
+++ b/code/game/objects/items/rogueitems/literary.dm
@@ -1,0 +1,59 @@
+
+/obj/item/literary
+	name = "novice's guide to literature"
+	desc = "A book featuring an alphabet, sentences of varying complexity, and common symbols that, altogether, allow the user to train their reading skills up to a point. The more advanced the guide, the higher the limit and the more literate you must be to study it.."
+	icon = 'icons/roguetown/items/books.dmi'
+	icon_state = "book_1"
+	var/exppercycle = 5
+	var/minexp = 0
+	var/maxexp = 101
+	var/skilltoteach = /datum/skill/misc/reading
+
+/obj/item/literary/apprentice
+	name = "apprentice's guide to literature"
+	icon_state = "book2_1"
+	minexp = 100
+	maxexp = 251
+	exppercycle = 13
+
+/obj/item/literary/journeyman
+	name = "journeyman's guide to literature"
+	icon_state = "book3_1"
+	minexp = 250
+	maxexp = 501
+	exppercycle = 25
+
+/obj/item/literary/expert
+	name = "expert's guide to literature"
+	icon_state = "book4_1"
+	minexp = 500
+	maxexp = 901
+	exppercycle = 45
+
+/obj/item/literary/master
+	name = "master's guide to literature"
+	icon_state = "book5_1"
+	minexp = 900
+	maxexp = 1501
+	exppercycle = 75
+
+/obj/item/literary/attack_self(mob/user)
+	. = ..()
+	attemptlearn(user)
+
+/obj/item/literary/proc/attemptlearn(mob/user)
+	if(user.mind && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/userskill = H.mind.get_skill_level(skilltoteach)
+		var/intbonus = H.STAINT - 10
+		if(userskill < minexp)
+			to_chat(user, "<span class='warning'>This guide is too advanced for me to study!</span>")
+			return
+		if(userskill < maxexp)
+			to_chat(user, "You begin to study the [src.name]!")
+			if(do_after(H, 5 SECONDS))
+				user.mind.adjust_experience(skilltoteach, exppercycle + intbonus)
+				attemptlearn(user)
+		else
+			to_chat(user, "<span class='warning'>This guide is too simple for me to learn any more from!</span>")
+			return

--- a/code/game/objects/items/rogueitems/literary.dm
+++ b/code/game/objects/items/rogueitems/literary.dm
@@ -5,37 +5,37 @@
 	icon = 'icons/roguetown/items/books.dmi'
 	icon_state = "book_1"
 	var/exppercycle = 5
-	var/minexp = 0
-	var/maxexp = 101
+	var/minskill = 0
+	var/maxskill = 1
 	var/skilltoteach = /datum/skill/misc/reading
 
 /obj/item/literary/apprentice
 	name = "apprentice's guide to literature"
 	icon_state = "book2_1"
-	minexp = 100
-	maxexp = 251
-	exppercycle = 13
+	minskill = 1
+	maxskill = 2
+	exppercycle = 8
 
 /obj/item/literary/journeyman
 	name = "journeyman's guide to literature"
 	icon_state = "book3_1"
-	minexp = 250
-	maxexp = 501
-	exppercycle = 25
+	minskill = 2
+	maxskill = 3
+	exppercycle = 13
 
 /obj/item/literary/expert
 	name = "expert's guide to literature"
 	icon_state = "book4_1"
-	minexp = 500
-	maxexp = 901
-	exppercycle = 45
+	minskill = 3
+	maxskill = 4
+	exppercycle = 20
 
 /obj/item/literary/master
 	name = "master's guide to literature"
 	icon_state = "book5_1"
-	minexp = 900
-	maxexp = 1501
-	exppercycle = 75
+	minskill = 4
+	maxskill = 5
+	exppercycle = 30
 
 /obj/item/literary/attack_self(mob/user)
 	. = ..()
@@ -46,10 +46,10 @@
 		var/mob/living/carbon/human/H = user
 		var/userskill = H.mind.get_skill_level(skilltoteach)
 		var/intbonus = H.STAINT - 10
-		if(userskill < minexp)
+		if(userskill < minskill)
 			to_chat(user, "<span class='warning'>This guide is too advanced for me to study!</span>")
 			return
-		if(userskill < maxexp)
+		if(userskill < maxskill)
 			to_chat(user, "You begin to study the [src.name]!")
 			if(do_after(H, 5 SECONDS))
 				user.mind.adjust_experience(skilltoteach, exppercycle + intbonus)
@@ -57,3 +57,5 @@
 		else
 			to_chat(user, "<span class='warning'>This guide is too simple for me to learn any more from!</span>")
 			return
+	else
+		return

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -436,3 +436,4 @@
 	name = "master's guide to literature"
 	result = list(/obj/item/literary/master)
 	craftdiff = 6
+	verbage = "writes"

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -395,3 +395,44 @@
 	skillcraft = /datum/skill/craft/traps
 	craftdiff = 1
 	verbage = "put together"
+
+/datum/crafting_recipe/roguetown/paperscroll
+	name = "scroll of parchment (x5)"
+	result = list(/obj/item/paper/scroll,
+				  /obj/item/paper/scroll,
+				  /obj/item/paper/scroll,
+				  /obj/item/paper/scroll,
+				  /obj/item/paper/scroll)
+	reqs = list(/obj/item/grown/log/tree/small = 1,
+	/datum/reagent/water = 50)
+	tools = list(/obj/item/rogueweapon/huntingknife = 1)
+	structurecraft = /obj/structure/fluff/dryingrack
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/readingscroll
+	name = "novice's guide to literature"
+	result = list(/obj/item/literary)
+	reqs = list(/obj/item/paper/scroll = 5)
+	req_table = TRUE
+	skillcraft = /datum/skill/misc/reading
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/readingscroll/apprentice
+	name = "apprentice's guide to literature"
+	result = list(/obj/item/literary/apprentice)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/readingscroll/journeyman
+	name = "journeyman's guide to literature"
+	result = list(/obj/item/literary/journeyman)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/readingscroll/expert
+	name = "expert's guide to literature"
+	result = list(/obj/item/literary/expert)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/readingscroll/master
+	name = "master's guide to literature"
+	result = list(/obj/item/literary/master)
+	craftdiff = 6

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1124,6 +1124,7 @@
 #include "code\game\objects\items\rogueitems\instruments.dm"
 #include "code\game\objects\items\rogueitems\keyrings.dm"
 #include "code\game\objects\items\rogueitems\keys.dm"
+#include "code\game\objects\items\rogueitems\literary.dm"
 #include "code\game\objects\items\rogueitems\magic.dm"
 #include "code\game\objects\items\rogueitems\natural.dm"
 #include "code\game\objects\items\rogueitems\needle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Currently, the only way to train the reading skill is to take any book and smack a training dummy with it. This is funny, but it's also stupid from an immersion standpoint so I put this little number together to offer an alternative.

First of all, you can now craft scrolls of parchment in batches of 5. You need any kind of hunting knife (such as stone knife; not consumed), a drying rack in front of you, a bucket at least half-full of water, and a small log. The crafting difficulty is 1 for this.

To make a guide to literacy, you need five scrolls of parchment, a feather (not consumed), and a table in front of you. The craftdiff for each level of guide is always 1 level higher than the skill it trains you up to, and the associated skill is reading. Technically this means it is possible for those with 11 or more intelligence to craft the guide for the level above their current skill, but I'm okay with that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The benefits mostly speak for themselves; those with reading skill can at minimum teach the illiterate to read, which may or may not be illegalized or encouraged by the king in any given round, and maybe people can pay a beggar or an orphan to deliver messages to other people.

As an aside, the same item framework I made for the literary guides makes it trivial to add guides for OTHER skills later on, too.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
