### PR TITLE
Fixes money throwing

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -46,13 +46,11 @@
 	if(isturf(T) && quantity > 1)
 		var/obj/structure/table/TA = locate() in T
 		if(!TA) //no table
-			for(var/i in 2 to quantity) // exclude the first coin
-				var/obj/item/roguecoin/new_coin = new type(T)
-				new_coin.set_quantity(1) // prevent exploits with coin piles
-				new_coin.pixel_x = rand(-8, 8)
-				new_coin.pixel_y = rand(-5, 5)
-
-	set_quantity(1)
+			var/obj/item/roguecoin/new_coin = new type(T)
+			new_coin.set_quantity(1) // prevent exploits with coin piles
+			new_coin.pixel_x = rand(-8, 8)
+			new_coin.pixel_y = rand(-5, 5)
+			set_quantity(quantity - 1)
 
 /obj/item/roguecoin/get_real_price()
 	return sellprice * quantity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Turns out throwing a coin stack causes it to all vanish into the void. This fixes behavior so coins only scatter if you don't throw them onto a table.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Goodbye deflation machine.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
