### PR TITLE
Adds non-clerical version of Diagnose spell to Doctors/Court Physician

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/towndoctor.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/towndoctor.dm
@@ -51,6 +51,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		if(H.age == AGE_OLD)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 1)

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -73,6 +73,7 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 6, TRUE)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		H.change_stat("strength", -1)
 		H.change_stat("constitution", -1)
 		H.change_stat("intelligence", 3)

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -1,4 +1,4 @@
-// Diagnose 
+// Diagnose
 /obj/effect/proc_holder/spell/invoked/diagnose
 	name = "Diagnose"
 	overlay_state = "diagnose"
@@ -22,6 +22,14 @@
 		human_target.check_for_injuries(user)
 		return TRUE
 	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/diagnose/secular
+	name = "Secular Diagnosis"
+	overlay_state = "diagnose"
+	range = 1
+	associated_skill = /datum/skill/misc/medicine
+	miracle = FALSE
+	devotion_cost = 0 //Doctors are not clerics
 
 // Limb or organ attachment
 /obj/effect/proc_holder/spell/invoked/attach_bodypart


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR adds a non-miracle subtype of the Diagnose spell and grants it to doctors and the court physician. Since the Accomplished Physician trait will likely be removed in the future, and since two people commented on my last PR suggesting this be added, I've gone ahead and coded it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes sense that dedicated doctor classes would know enough about anatomy to diagnose someone without needing the power of faith to do so, and it'll be a great QoL addition for the classes, since most doctors are already followers of Pestra anyway.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
