### PR TITLE
Zombies can no longer run in the 90s

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -54,7 +54,7 @@
 #define TRAIT_IWASHAUNTED "iwashaunted" //prevents spawning a haunt from a decapitated body twice
 #define TRAIT_SCHIZO_AMBIENCE "schizo_ambience" //replaces all ambience with creepy shit
 #define TRAIT_SCREENSHAKE "screenshake" //screen will always be shaking, you cannot stop it
-#define TRAIT_ZOMBIFIED "Decayed Flesh"
+#define TRAIT_NORUN "Decayed Flesh"
 
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WEBWALK = "I can move freely between webs.",

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -54,6 +54,7 @@
 #define TRAIT_IWASHAUNTED "iwashaunted" //prevents spawning a haunt from a decapitated body twice
 #define TRAIT_SCHIZO_AMBIENCE "schizo_ambience" //replaces all ambience with creepy shit
 #define TRAIT_SCREENSHAKE "screenshake" //screen will always be shaking, you cannot stop it
+#define TRAIT_ZOMBIFIED "Decayed Flesh"
 
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WEBWALK = "I can move freely between webs.",
@@ -95,6 +96,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_CRACKHEAD = span_love("I can use drugs as much as I want!"),
 	TRAIT_COMMIE = span_bloody("I can recognize other free men, and they can recognize me too."),
 	TRAIT_IAMASURGEON = "My skills as a surgeon go beyond all these other hacks playing doctor. The more medical experience I have, the less likely I am to waste thread when stitching people up.",
+	TRAIT_ZOMBIFIED = span_warning("My body has atrophied in my state of decay; my leg joints just don't have the strength or durability for running anymore"),
 ))
 
 // trait accessor defines

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_CRACKHEAD = span_love("I can use drugs as much as I want!"),
 	TRAIT_COMMIE = span_bloody("I can recognize other free men, and they can recognize me too."),
 	TRAIT_IAMASURGEON = "My skills as a surgeon go beyond all these other hacks playing doctor. The more medical experience I have, the less likely I am to waste thread when stitching people up.",
-	TRAIT_ZOMBIFIED = span_warning("My body has atrophied in my state of decay; my leg joints just don't have the strength or durability for running anymore"),
+	TRAIT_NORUN = span_warning("My body has atrophied in my state of decay; my leg joints just don't have the strength or durability for running anymore"),
 ))
 
 // trait accessor defines

--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -46,7 +46,7 @@
 		TRAIT_ZOMBIE_IMMUNE,
 		TRAIT_EMOTEMUTE,
 		TRAIT_ROTMAN,
-		TRAIT_ZOMBIFIED
+		TRAIT_NORUN
 	)
 	/// Traits applied to the owner when we are cured and turn into just "rotmen"
 	var/static/list/traits_rotman = list(

--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -46,6 +46,7 @@
 		TRAIT_ZOMBIE_IMMUNE,
 		TRAIT_EMOTEMUTE,
 		TRAIT_ROTMAN,
+		TRAIT_ZOMBIFIED
 	)
 	/// Traits applied to the owner when we are cured and turn into just "rotmen"
 	var/static/list/traits_rotman = list(
@@ -331,7 +332,7 @@
 	if(!zombie_antag)
 		return
 	if(stat >= DEAD) //do shit the natural way i guess
-		return 
+		return
 	to_chat(src, span_danger("I feel horrible... REALLY horrible..."))
 	mob_timers["puke"] = world.time
 	vomit(1, blood = TRUE, stun = FALSE)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -577,7 +577,8 @@
 	if(m_intent == MOVE_INTENT_RUN)
 		m_intent = MOVE_INTENT_WALK
 	else
-		m_intent = MOVE_INTENT_RUN
+		if(!HAS_TRAIT(user, TRAIT_ZOMBIFIED))
+			m_intent = MOVE_INTENT_RUN
 	if(hud_used && hud_used.static_inventory)
 		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.update_icon()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -579,6 +579,8 @@
 	else
 		if(!HAS_TRAIT(user, TRAIT_ZOMBIFIED))
 			m_intent = MOVE_INTENT_RUN
+		else
+			to_chat(user, span_warning("My joints have decayed too much for running!"))
 	if(hud_used && hud_used.static_inventory)
 		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.update_icon()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -577,7 +577,7 @@
 	if(m_intent == MOVE_INTENT_RUN)
 		m_intent = MOVE_INTENT_WALK
 	else
-		if(!HAS_TRAIT(user, TRAIT_ZOMBIFIED))
+		if(!HAS_TRAIT(user, TRAIT_NORUN))
 			m_intent = MOVE_INTENT_RUN
 		else
 			to_chat(user, span_warning("My joints have decayed too much for running!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds TRAIT_ZOMBIFIED, aka "Decayed Flesh," to zombies. This trait prevents a mob from activating run intent, and notifies them that they can't run anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nobody wants to have to deal with a hit and run zombie who sprints away at the speed of Plaid at the slightest resistance to just forever be a pain in the ass trying to fish for infectious bites all round.

Commit to the bit(e) or **super** die (again).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
