### PR TITLE
Changes smithing to quality-per hit with mistake counterbalance system

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -19,15 +19,13 @@
 #define GetSkillRef(A) (SSskills.all_skills[A])
 
 //Blacksmith resultant skills
-#define BLACKSMITH_LEVEL_MIN -10
-#define BLACKSMITH_LEVEL_SPOIL -2 // you can only get this by using spoilt bars and crude skill
-#define BLACKSMITH_LEVEL_AWFUL -1 // you can only get this by using poor bars and crude skill (or spoilt bars and rough skill)
-#define BLACKSMITH_LEVEL_CRUDE 0
-#define BLACKSMITH_LEVEL_ROUGH 1
-#define BLACKSMITH_LEVEL_COMPETENT 2
-#define BLACKSMITH_LEVEL_FINE 3
-#define BLACKSMITH_LEVEL_FLAWLESS 4
-#define BLACKSMITH_LEVEL_LEGENDARY 5
+#define BLACKSMITH_LEVEL_MIN 0 // you can only get this by using poor bars and crude skill (or spoilt bars and rough skill)
+#define BLACKSMITH_LEVEL_CRUDE 1
+#define BLACKSMITH_LEVEL_ROUGH 2
+#define BLACKSMITH_LEVEL_COMPETENT 3
+#define BLACKSMITH_LEVEL_FINE 4
+#define BLACKSMITH_LEVEL_FLAWLESS 5
+#define BLACKSMITH_LEVEL_LEGENDARY 6
 #define BLACKSMITH_LEVEL_MAX 10
 
 //Forging resultant skills

--- a/code/modules/hydroponics/roguebin.dm
+++ b/code/modules/hydroponics/roguebin.dm
@@ -160,8 +160,8 @@
 			if(!T.hingot.currecipe)
 				to_chat(user, "<span class='warning'>Huh?</span>")
 				return
-			if(T.hingot.currecipe.progress != 100)
-				to_chat(user, "<span class='warning'>It's not finished yet.</span>")
+			if(T.hingot.currecipe.quality <= 70)
+				to_chat(user, "<span class='warning'>It's not even crudely finished yet.</span>")
 				return
 			if(!T.hott)
 				to_chat(user, "<span class='warning'>I need to heat it to temper the metal.</span>")

--- a/code/modules/hydroponics/roguebin.dm
+++ b/code/modules/hydroponics/roguebin.dm
@@ -160,7 +160,7 @@
 			if(!T.hingot.currecipe)
 				to_chat(user, "<span class='warning'>Huh?</span>")
 				return
-			if(T.hingot.currecipe.quality <= 70)
+			if(T.hingot.currecipe.quality_level < 1)
 				to_chat(user, "<span class='warning'>It's not even crudely finished yet.</span>")
 				return
 			if(!T.hott)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
@@ -98,20 +98,23 @@
 		return
 
 	if(hingot?.currecipe?.additional_items_text)
+		var/datum/anvil_recipe/currentrecipe = hingot.currecipe
 		var/found_in_list = FALSE
-		for(var/I_list in hingot.currecipe.additional_items)
+		for(var/I_list in currentrecipe.additional_items)
 			if(istype(W, I_list))
 				found_in_list = TRUE
+				currentrecipe.additional_items -= I_list
+				break
 		if(!found_in_list)
 			return
-		hingot.currecipe.item_added(user, W)
+		currentrecipe.handle_additional_items(user, W)
 		if(istype(W, /obj/item/ingot))
 			var/obj/item/ingot/I = W
-			hingot.currecipe.material_quality += I.quality
+			currentrecipe.material_quality += I.quality
 			previous_material_quality = I.quality
 		else
-			hingot.currecipe.material_quality += previous_material_quality
-		hingot.currecipe.num_of_materials += 1 
+			currentrecipe.material_quality += previous_material_quality
+		currentrecipe.num_of_materials += 1
 		qdel(W)
 		return
 

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
@@ -97,8 +97,14 @@
 
 		return
 
-	if(hingot && hingot.currecipe && hingot.currecipe.needed_item && istype(W, hingot.currecipe.needed_item))
-		hingot.currecipe.item_added(user)
+	if(hingot?.currecipe?.additional_items_text)
+		var/found_in_list = FALSE
+		for(var/I_list in hingot.currecipe.additional_items)
+			if(istype(W, I_list))
+				found_in_list = TRUE
+		if(!found_in_list)
+			return
+		hingot.currecipe.item_added(user, W)
 		if(istype(W, /obj/item/ingot))
 			var/obj/item/ingot/I = W
 			hingot.currecipe.material_quality += I.quality

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -54,7 +54,7 @@
 			else
 				var/datum/mind/smelter_mind = user.mind
 				var/smelter_exp = smelter_mind.get_skill_level(/datum/skill/craft/smelting)
-				ore[W] = floor(rand(smelter_exp*15, max(63, smelter_exp*25))/25) // (0-25 spoil, 25-50 poor, 50-75, normal, 75-onwards good) no skill = 0, 63, novice = 15, 63, apprentice = 30, 63, skilled = 45, 75, expert = 60, 100, master = 75, 125, legendary = 100, 150, (may want to add a tier above good)
+				ore[W] = min(floor(rand(smelter_exp*15, max(63, smelter_exp*25))/25),3) // (0-25 spoil, 25-50 poor, 50-75, normal, 75-onwards good) no skill = 0, 63, novice = 15, 63, apprentice = 30, 63, skilled = 45, 75, expert = 60, 100, master = 75, 125, legendary = 100, 150, (may want to add a tier above good)
 			user.visible_message("<span class='warning'>[user] puts something in the smelter.</span>")
 			cooking = 0
 			return
@@ -142,7 +142,7 @@
 							ore_deleted += 1
 							ore -= I
 							qdel(I)
-						floor_mean_quality = floor(floor_mean_quality/ore_deleted)
+						floor_mean_quality = min(floor(floor_mean_quality/ore_deleted),3)
 						for(var/i in 1 to maxore)
 							var/obj/item/R = new alloy(src, floor_mean_quality)
 							ore += R


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When you hit you do "((breakthrough ? 15 : 10)+material_quality)/num_of_materials"
When you reach 70 from doing this, you advance a quality level.
Whenever you hit, you have a percentage chance to make a mistake (dependent on skill)
Per ingot in your recipe, you can make a mistake 3 times. When you reach your max mistakes, the work disintegrates.

Also fixes more-than-good ingots.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
