### PR TITLE
Adds oldtown to map rotation

### DIFF
--- a/_maps/oldtown.json
+++ b/_maps/oldtown.json
@@ -1,5 +1,5 @@
 {
-    "map_name": "Old Roguetown",
+    "map_name": "Old Blackstone",
     "map_path": "map_files/oldtown",
     "map_file": "oldtown.dmm",
 	"traits": [{"Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1}],

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -23,3 +23,8 @@ endmap
 map blackstonedense
 	votable
 endmap
+
+map oldtown
+	votable
+	maxplayers 70
+endmap


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds revamped old roguetown map (https://github.com/Blackstone-SS13/BLACKSTONE/pull/1343) as "Old Blackstone". Capped at 70 max players. **HAS CONFIG CHANGES**.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More map cool. Max player count can be adjusted.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
