### PR TITLE
Adds Prince (and the other one) to latejoin

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -4,7 +4,7 @@
 	flag = PRINCE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 0
+	total_positions = 2
 	spawn_positions = 2
 	allowed_races = list(
 		"Humen",


### PR DESCRIPTION
The 'queen' can randomly show up and change the entire rounds narrative or replace the king

Why not some SHITTER kids too lol

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Let's the Prince or Princess show up and get stabbed on the way to the keep like their mom because why the hell not
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Technically as a learner role, it might be nice if there are none for a player to show up as one.
I am aware that this adds two slots to "compete for the crown" but they shouldn't really be aiming to do that, as they won't be late join aspirants. Obviously aspirant is a fucking joke, but you know what I mean.

I also almost always see both prince slots taken every game, with more than two people rolling for it.
This is mainly for lowpop rounds that drag on for a long time with a need to replace the king.
...and because Prince is fun, and I love seeing people play this role and causing massive shit with it lol.

Just vulfpit your gremlin prince Kings, what could go wrong lol?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
