### PR TITLE
Disables autobite while zombies are unplayable

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zomble.dm
+++ b/code/modules/antagonists/roguetown/villain/zomble.dm
@@ -225,16 +225,16 @@
 		zombie.emote("idle")
 		next_idle_sound = world.time + rand(5 SECONDS, 10 SECONDS)
 	//fuck friendly zombies - tries to bite humans in range
-	if(world.time - last_bite < 10 SECONDS)
+/*	if(world.time - last_bite < 10 SECONDS)
 		return
 	var/obj/item/grabbing/bite/bite = zombie.get_item_by_slot(SLOT_MOUTH)
 	if(!bite || !get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH, grabs = TRUE))
 		for(var/mob/living/carbon/human in view(1, zombie))
-			if((human.mob_biotypes & MOB_UNDEAD) || ("undead" in human.faction) || HAS_TRAIT(human, TRAIT_ZOMBIE_IMMUNE))
+			if((human.mob_biotypes & MOB_UNDEAD) || ("undead" in human.faction) || HAS_TRAIT(human, TRAIT_ZOMBIE_IMMUNE)) //Uncomment auto-bite when playable zombies are re-implemented.
 				continue
 			human.onbite(zombie)
 	else if(istype(bite))
-		bite.bitelimb(zombie)
+		bite.bitelimb(zombie)*/
 
 //Infected wake param is just a transition from living to zombie, via zombie_infect()
 //Previously you just died without warning in 3 minutes, now you just become an antag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Because the autobite functions separately from the zombie's AI attacks, it effectively attacks twice per round. This is super rude since NPCs don't interact with stamina, which is intended to balance combat.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zombies will still attack normally with AI, but until they are playable again, autobite is not necessary.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
