### PR TITLE
Adds the Eora Patron Trait... to Eora! (Wow!)

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -48,6 +48,7 @@
 	domain = "Goddess of Degeneracy, Debauchery and Addiction"
 	desc = "The Fallen Daughter of Psydon, once used to be a goddess of love and family but has now fallen from grace as she leads mortals to hedonism."
 	worshippers = "Drunkards, Junkies, Gamblers and Bards"
+	mob_traits = list(TRAIT_CRACKHEAD)
 	confess_lines = list(
 		"EORA BRINGS ME PLEASURE!",
 		"EORA BRINGS ME LUCK!",


### PR DESCRIPTION
Eora doesn't have this, unless it was removed intentionally and I missed that somewhere in the history section... I think she should... probably have the trait?
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Gives the Eora Patron "TRAIT_CRACKHEAD" so her followers can snort all the moondust and spice they want (until they roll the instant death proc on a heart attack which I am fairly certain this DOES NOT prevent.)
## Why It's Good For The Game
Drunkard gets it. All her followers should.
That's the entire reason somebody made the trait, right?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
