### PR TITLE
Merchant goldface fix/expansion

### DIFF
--- a/code/modules/cargo/packsrogue/apparel.dm
+++ b/code/modules/cargo/packsrogue/apparel.dm
@@ -6,53 +6,45 @@
 
 /datum/supply_pack/rogue/apparel/hoods
 	name = "Shoulder Hood"
-	cost = 30
-	contains = list(/obj/item/clothing/head/roguetown/roguehood/random,
-					/obj/item/clothing/head/roguetown/roguehood/random,
-					/obj/item/clothing/head/roguetown/roguehood/random)
+	cost = 10
+	contains = list(/obj/item/clothing/head/roguetown/roguehood/random)
 
-/datum/supply_pack/rogue/apparel/bags
+/datum/supply_pack/rogue/apparel/bags/satchel
 	name = "Satchels"
 	cost = 10
-	contains = list(/obj/item/storage/backpack/rogue/satchel,
-					/obj/item/storage/backpack/rogue/satchel,
-					/obj/item/storage/backpack/rogue/satchel)
+	contains = list(/obj/item/storage/backpack/rogue/satchel)
 
-/datum/supply_pack/rogue/apparel/bags
+/datum/supply_pack/rogue/apparel/bags/pouch
 	name = "Pouches"
-	cost = 5
-	contains = list(/obj/item/storage/belt/rogue/pouch,
-					/obj/item/storage/belt/rogue/pouch,
-					/obj/item/storage/belt/rogue/pouch,
-					/obj/item/storage/belt/rogue/pouch)
+	cost = 10
+	contains = list(/obj/item/storage/belt/rogue/pouch)
 
 /datum/supply_pack/rogue/apparel/belts
 	name = "Belts"
-	cost = 5
-	contains = list(/obj/item/storage/belt/rogue/leather,
-					/obj/item/storage/belt/rogue/leather,
-					/obj/item/storage/belt/rogue/leather)
+	cost = 10
+	contains = list(/obj/item/storage/belt/rogue/leather)
 
-/datum/supply_pack/rogue/apparel/crosses
+/datum/supply_pack/rogue/apparel/crosses/silver
 	name = "Silver Cross"
 	cost = 150
+	contains = list(/obj/item/clothing/neck/roguetown/psicross/silver)
+
+/datum/supply_pack/rogue/apparel/crosses/psicross
+	name = "Psicross"
+	cost = 30
 	contains = list(/obj/item/clothing/neck/roguetown/psicross)
 
-
-/datum/supply_pack/rogue/apparel/gloves
+/datum/supply_pack/rogue/apparel/gloves/leather
 	name = "Leather Gloves"
 	cost = 10
-	contains = list(/obj/item/clothing/gloves/roguetown/leather,
-					/obj/item/clothing/gloves/roguetown/leather)
+	contains = list(/obj/item/clothing/gloves/roguetown/leather)
 
-/datum/supply_pack/rogue/apparel/boots
+/datum/supply_pack/rogue/apparel/boots/leather
 	name = "Leather Boots"
 	cost = 10
-	contains = list(/obj/item/clothing/shoes/roguetown/boots/leather,
-					/obj/item/clothing/shoes/roguetown/boots/leather)
+	contains = list(/obj/item/clothing/shoes/roguetown/boots/leather)
 
-/datum/supply_pack/rogue/apparel/cloaks
+/datum/supply_pack/rogue/apparel/cloaks/leather
 	name = "Rain Cloak"
 	cost = 15
-	contains = list(/obj/item/clothing/cloak/raincloak/brown,
-					/obj/item/clothing/cloak/raincloak/mortus)
+	contains = list(/obj/item/clothing/cloak/raincloak/brown)

--- a/code/modules/cargo/packsrogue/armor.dm
+++ b/code/modules/cargo/packsrogue/armor.dm
@@ -4,43 +4,77 @@
 	crate_name = "merchant guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
-/datum/supply_pack/rogue/armor/bracers
-	name = "Bracers"
-	cost = 15
-	contains = list(/obj/item/clothing/wrists/roguetown/bracers/leather,
-					/obj/item/clothing/wrists/roguetown/bracers/leather,
-					/obj/item/clothing/wrists/roguetown/bracers/leather)
-
 /datum/supply_pack/rogue/armor/helmet
-	name = "Helmet"
+	name = "Steel Helmet"
 	cost = 30
 	contains = list(/obj/item/clothing/head/roguetown/helmet)
+	
+/datum/supply_pack/rogue/armor/coif
+	name = "Cloth Coif"
+	cost = 10
+	contains = list(/obj/item/clothing/neck/roguetown/coif)
+	
+/datum/supply_pack/rogue/armor/coif/steel
+	name = "Steel Coif"
+	cost = 30
+	contains = list(/obj/item/clothing/neck/roguetown/chaincoif)
+	
+/datum/supply_pack/rogue/armor/mask/steel
+	name = "Steel Mask"
+	cost = 30
+	contains = list(/obj/item/clothing/mask/rogue/facemask/steel)
+
+/datum/supply_pack/rogue/armor/bracers
+	name = "Steel Bracers"
+	cost = 30
+	contains = list(/obj/item/clothing/wrists/roguetown/bracers)
+
+/datum/supply_pack/rogue/armor/chaingauntlets
+	name = "Steel Chain Gauntlets"
+	cost = 20
+	contains = list(/obj/item/clothing/gloves/roguetown/chain)
+	
+/datum/supply_pack/rogue/armor/boots
+	name = "Steel Boots"
+	cost = 30
+	contains = list(/obj/item/clothing/shoes/roguetown/boots)
 
 /datum/supply_pack/rogue/armor/gambeson
 	name = "Gambesons"
 	cost = 30
-	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson,
-					/obj/item/clothing/suit/roguetown/armor/gambeson)
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson)
 
 /datum/supply_pack/rogue/armor/leather
 	name = "Leather Armor"
-	cost = 25
-	contains = list(/obj/item/clothing/suit/roguetown/armor/leather,
-					/obj/item/clothing/suit/roguetown/armor/leather,
-					/obj/item/clothing/suit/roguetown/armor/leather)
+	cost = 10
+	contains = list(/obj/item/clothing/suit/roguetown/armor/leather)
 
-/datum/supply_pack/rogue/armor/leather
+/datum/supply_pack/rogue/armor/leather/studded
 	name = "Studded Leather Armor"
-	cost = 25
+	cost = 50
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/studded)
+	
+/datum/supply_pack/rogue/armor/chainmaille
+	name = "Chainmaille"
+	cost = 25
+	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/iron)
 
-/datum/supply_pack/rogue/armor/chainmail
-	name = "Chainmail Shirt"
+/datum/supply_pack/rogue/armor/haubergon
+	name = "Haubergon"
 	cost = 40
-	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail,
-					/obj/item/clothing/suit/roguetown/armor/chainmail)
+	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail)
+	
+/datum/supply_pack/rogue/armor/hauberk
+	name = "Hauberk"
+	cost = 80
+	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk)
 
 /datum/supply_pack/rogue/armor/halfplate
 	name = "Half-Plate Armor"
-	cost = 50
+	cost = 125
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/half)
+
+/datum/supply_pack/rogue/armor/plate/full
+	name = "Full Plate"
+	cost = 175
+	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full)

--- a/code/modules/cargo/packsrogue/food.dm
+++ b/code/modules/cargo/packsrogue/food.dm
@@ -6,44 +6,25 @@
 /datum/supply_pack/rogue/food/healthpot
 	name = "Healing Potion"
 	cost = 18
-	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
-
+	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
 /datum/supply_pack/rogue/food/manapot
 	name = "Manna Potion"
 	cost = 24
-	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-					/obj/item/reagent_containers/glass/bottle/rogue/manapot)
-
+	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/manapot)
 /datum/supply_pack/rogue/food/wineb
 	name = "Wine"
-	cost = 60
-	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/wine,
-					/obj/item/reagent_containers/glass/bottle/rogue/wine,
-					/obj/item/reagent_containers/glass/bottle/rogue/wine)
+	cost = 25
+	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/wine)
 
 /datum/supply_pack/rogue/food/meat
 	name = "Dry Meat"
-	cost = 15
-	contains = list(/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-					/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-					/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-					/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-					/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette)
+	cost = 5
+	contains = list(/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette)
 
 /datum/supply_pack/rogue/food/eggs
 	name = "Egg"
-	cost = 20
-	contains = list(/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg,
-					/obj/item/reagent_containers/food/snacks/egg)
+	cost = 5
+	contains = list(/obj/item/reagent_containers/food/snacks/egg)
 
 /datum/supply_pack/rogue/food/pepper
 	name = "Pepper"
@@ -52,14 +33,10 @@
 
 /datum/supply_pack/rogue/food/butter
 	name = "Butter"
-	cost = 10
-	contains = list(/obj/item/reagent_containers/food/snacks/butter,
-					/obj/item/reagent_containers/food/snacks/butter,
-					/obj/item/reagent_containers/food/snacks/butter)
+	cost = 5
+	contains = list(/obj/item/reagent_containers/food/snacks/butter)
 
 /datum/supply_pack/rogue/food/honey
 	name = "Honey"
-	cost = 30
-	contains = list(/obj/item/reagent_containers/food/snacks/rogue/honey,
-					/obj/item/reagent_containers/food/snacks/rogue/honey,
-					/obj/item/reagent_containers/food/snacks/rogue/honey)
+	cost = 10
+	contains = list(/obj/item/reagent_containers/food/snacks/rogue/honey)

--- a/code/modules/cargo/packsrogue/luxury.dm
+++ b/code/modules/cargo/packsrogue/luxury.dm
@@ -70,3 +70,7 @@
 	name = "Riddle of Steel"
 	cost = 400
 	contains = list(/obj/item/riddleofsteel)
+
+	name = "Riddle of Steel"
+	cost = 400
+	contains = list(/obj/item/riddleofsteel)

--- a/code/modules/cargo/packsrogue/seeds.dm
+++ b/code/modules/cargo/packsrogue/seeds.dm
@@ -7,44 +7,25 @@
 
 /datum/supply_pack/rogue/seeds/spelt
 	name = "Spelt"
-	cost = 11
-	contains = list(/obj/item/seeds/wheat,
-					/obj/item/seeds/wheat,
-					/obj/item/seeds/wheat,
-					/obj/item/seeds/wheat,
-					/obj/item/seeds/wheat,
-					/obj/item/seeds/wheat)
+	cost = 10
+	contains = list(/obj/item/seeds/wheat)
 
 /datum/supply_pack/rogue/seeds/apple
 	name = "Apple"
-	cost = 12
-	contains = list(/obj/item/seeds/apple,
-					/obj/item/seeds/apple,
-					/obj/item/seeds/apple,
-					/obj/item/seeds/apple,
-					/obj/item/seeds/apple)
+	cost = 10
+	contains = list(/obj/item/seeds/apple)
 
 /datum/supply_pack/rogue/seeds/weed
 	name = "Pipe Weed"
-	cost = 15
-	contains = list(/obj/item/seeds/pipeweed,
-					/obj/item/seeds/pipeweed,
-					/obj/item/seeds/pipeweed,
-					/obj/item/seeds/pipeweed,
-					/obj/item/seeds/pipeweed)
+	cost = 10
+	contains = list(/obj/item/seeds/pipeweed)
 
 /datum/supply_pack/rogue/seeds/sleaf
 	name = "Sweet Leaf"
-	cost = 30
-	contains = list(/obj/item/seeds/sweetleaf,
-					/obj/item/seeds/sweetleaf,
-					/obj/item/seeds/sweetleaf,
-					/obj/item/seeds/sweetleaf)
+	cost = 10
+	contains = list(/obj/item/seeds/sweetleaf)
 
 /datum/supply_pack/rogue/seeds/berry
 	name = "Berry"
 	cost = 10
-	contains = list(/obj/item/seeds/berryrogue,
-					/obj/item/seeds/berryrogue,
-					/obj/item/seeds/berryrogue,
-					/obj/item/seeds/berryrogue/poison)
+	contains = list(/obj/item/seeds/berryrogue)

--- a/code/modules/cargo/packsrogue/tools.dm
+++ b/code/modules/cargo/packsrogue/tools.dm
@@ -6,10 +6,8 @@
 
 /datum/supply_pack/rogue/tools/ropes
 	name = "Ropes"
-	cost = 15
-	contains = list(/obj/item/rope,
-					/obj/item/rope,
-					/obj/item/rope)
+	cost = 10
+	contains = list(/obj/item/rope)
 
 /*
 /datum/supply_pack/rogue/tools/scomst
@@ -24,58 +22,37 @@
 /datum/supply_pack/rogue/tools/chains
 	name = "Chains"
 	cost = 12
-	contains = list(/obj/item/rope/chain,
-					/obj/item/rope/chain,
-					/obj/item/rope/chain)
+	contains = list(/obj/item/rope/chain)
 
 /datum/supply_pack/rogue/tools/paper
 	name = "Paper"
 	cost = 3
-	contains = list(/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll)
+	contains = list(/obj/item/paper/scroll)
 
 /datum/supply_pack/rogue/tools/flint
 	name = "Flint"
 	cost = 35
-	contains = list(/obj/item/flint,
-					/obj/item/flint)
+	contains = list(/obj/item/flint)
 
 /datum/supply_pack/rogue/tools/bottl
 	name = "Glass Bottles"
-	cost = 15
-	contains = list(/obj/item/reagent_containers/glass/bottle/rogue,
-					/obj/item/reagent_containers/glass/bottle/rogue,
-					/obj/item/reagent_containers/glass/bottle/rogue)
+	cost = 10
+	contains = list(/obj/item/reagent_containers/glass/bottle/rogue)
 
 /datum/supply_pack/rogue/tools/matches
 	name = "Box of Matches"
-	cost = 15
-	contains = list(/obj/item/storage/box/matches,
-					/obj/item/storage/box/matches,
-					/obj/item/storage/box/matches)
+	cost = 10
+	contains = list(/obj/item/storage/box/matches)
 
 /datum/supply_pack/rogue/tools/pipes
 	name = "Pipes"
-	cost = 15
-	contains = list(/obj/item/clothing/mask/cigarette/pipe,
-					/obj/item/clothing/mask/cigarette/pipe,
-					/obj/item/clothing/mask/cigarette/pipe/westman)
+	cost = 5
+	contains = list(/obj/item/clothing/mask/cigarette/pipe)
 
 /datum/supply_pack/rogue/tools/bait
 	name = "Premium Fishing Bait"
-	cost = 25
-	contains = list(/obj/item/natural/worms/grubs,
-					/obj/item/natural/worms/grubs,
-					/obj/item/natural/worms/leech,
-					/obj/item/natural/worms/leech,
-					/obj/item/natural/worms/leech)
-
+	cost = 10
+	contains = list(/obj/item/natural/worms/grubs)
 
 /datum/supply_pack/rogue/tools/prarml
 	name = "Proesthetic Arm (L)"

--- a/code/modules/cargo/packsrogue/weapons.dm
+++ b/code/modules/cargo/packsrogue/weapons.dm
@@ -4,31 +4,45 @@
 	crate_name = "merchant guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
-/datum/supply_pack/rogue/weapons/swords
-	name = "Swords"
-	cost = 104
-	contains = list(/obj/item/rogueweapon/sword/iron,
-					/obj/item/rogueweapon/sword/iron,
-					/obj/item/rogueweapon/sword/iron)
+/datum/supply_pack/rogue/weapons/sword
+	name = "Sword"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/sword/iron)
 
-/datum/supply_pack/rogue/weapons/maces
-	name = "Maces"
-	cost = 100
-	contains = list(/obj/item/rogueweapon/mace,
-					/obj/item/rogueweapon/mace,
-					/obj/item/rogueweapon/mace)
+/datum/supply_pack/rogue/weapons/mace
+	name = "Mace"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/mace)
+	
+/datum/supply_pack/rogue/weapons/dagger
+	name = "Iron Dagger"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/huntingknife/idagger)
+	
+/datum/supply_pack/rogue/weapons/axe
+	name = "Iron axe"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut)
+	
+/datum/supply_pack/rogue/weapons/spear
+	name = "Iron spear"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/spear)
+
+/datum/supply_pack/rogue/weapons/flail
+	name = "Iron flail"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/flail)
 
 /datum/supply_pack/rogue/weapons/stunmace
 	name = "Stunmace"
 	cost = 290
 	contains = list(/obj/item/rogueweapon/mace/stunmace)
 
-/datum/supply_pack/rogue/weapons/shields
-	name = "Wooden Shields"
-	cost = 44
-	contains = list(/obj/item/rogueweapon/shield/wood,
-					/obj/item/rogueweapon/shield/wood,
-					/obj/item/rogueweapon/shield/wood)
+/datum/supply_pack/rogue/weapons/shield
+	name = "Wooden Shield"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/shield/wood)
 
 /datum/supply_pack/rogue/weapons/crossbow
 	name = "Crossbow"
@@ -37,39 +51,18 @@
 
 /datum/supply_pack/rogue/weapons/bow
 	name = "Bow"
-	cost = 5
+	cost = 15
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow)
 
-/datum/supply_pack/rogue/weapons/quivers
-	name = "Quivers"
+/datum/supply_pack/rogue/weapons/quiver
+	name = "Quiver"
 	cost = 15
-	contains = list(/obj/item/quiver,
-					/obj/item/quiver,
-					/obj/item/quiver)
+	contains = list(/obj/item/quiver)
 
-/datum/supply_pack/rogue/weapons/arrows
+/datum/supply_pack/rogue/weapons/arrow
 	name = "Arrows"
-	cost = 15
-	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow,
-					/obj/item/ammo_casing/caseless/rogue/arrow)
+	cost = 1
+	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow)
 /*
 /datum/supply_pack/rogue/weapons/Parrows
 	name = "Poisoned Arrows"
@@ -93,15 +86,10 @@
 					/obj/item/ammo_casing/caseless/rogue/arrow/poison)
 */
 
-/datum/supply_pack/rogue/weapons/bolts
+/datum/supply_pack/rogue/weapons/bolt
 	name = "Bolts"
-	cost = 16
-	contains = list(/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt)
+	cost = 2
+	contains = list(/obj/item/ammo_casing/caseless/rogue/bolt)
 /*
 /datum/supply_pack/rogue/weapons/Pbolts
 	name = "Poisoned Bolts"
@@ -113,3 +101,4 @@
 					/obj/item/ammo_casing/caseless/rogue/bolt/poison,
 					/obj/item/ammo_casing/caseless/rogue/bolt/poison)
 */
+


### PR DESCRIPTION
## About The Pull Request

Some items now have separate datums and will show up appropriately (you can now buy satchels)
Cleaned up unnecessary lines since it only outputs 1 item on buy anyway
Expanded the merchant's inventory. Lots of armor, some weapons, silver psicross purchase now actually gives you a silver one + regular psicross option.
Changed prices appropriate to the fact you don't purchase in bulk like you used to in the long past.

## Why It's Good For The Game

Merchant's inventory has been dogshit since the beginning as well as the pricing being whack due to it being set up for getting multiple items per purchase, but only receiving one. Expanded inventory, rational pricing, and a few bug fixes should make it a more enjoyable experience all around.
