### PR TITLE
Apple export/import increased to 10 from 5

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -128,7 +128,7 @@
 	withdraw_price = 5
 	transport_fee = 1
 	export_price = 5
-	importexport_amt = 5
+	importexport_amt = 10
 
 /datum/roguestock/stockpile/meat
 	name = "Meat"


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

It's common to see apples mass-sold and when you sell them you get autoscrolled back the top making selling a lot of these a turbo dick twister.

This relaxes that amount of twisting by half at least.