### PR TITLE
Custom key naming fix

### DIFF
--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -315,7 +315,7 @@
 	if(istype(I, /obj/item/rogueweapon/hammer))
 		var/input = (input(user, "What would you name this key?", "", "") as text) 
 		if(input)
-			name = name + " key"
+			name = input + " key"
 			to_chat(user, span_notice("You rename the key to [name]."))
 
 //custom key blank


### PR DESCRIPTION
Just a tiny bug fix for me and other 1.5 men who know how to use custom locks and keys

Now we can name custom keys properly, instead of "Custom key key key key..."
