### PR TITLE
Rewords Flaw information to be less misleading (and a tiny fix for broken glasses debuff)

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -32,8 +32,8 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 		return TRUE
 
 /datum/charflaw/randflaw
-	name = "Random Flaw"
-	desc = "Chooses a random flaw (50% chance for no flaw)"
+	name = "Random or None"
+	desc = "A 50% chance to be given a random flaw, or a 50% chance to have NO flaw."
 	var/nochekk = TRUE
 
 /datum/charflaw/randflaw/flaw_on_life(mob/user)
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 
 /datum/charflaw/noflaw
 	name = "No Flaw (3 TRI)"
-	desc = "I'm a normal person, how rare! (Consumes 3 triumphs or randomizes)"
+	desc = "I'm a normal person, how rare! (Consumes 3 triumphs or gives a random flaw.)"
 	var/nochekk = TRUE
 
 /datum/charflaw/noflaw/flaw_on_life(mob/user)
@@ -118,7 +118,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 /datum/status_effect/debuff/badvision
 	id = "badvision"
 	alert_type = null
-	effectedstats = list("perception" = -20, "speed" = -5,"fortune" = -20)
+	effectedstats = list("perception" = -20, "speed" = -5)
 	duration = 100
 
 /datum/charflaw/badsight/on_mob_creation(mob/user)
@@ -133,7 +133,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 
 /datum/charflaw/paranoid
 	name = "Paranoid"
-	desc = "I'm even more anxious than most towners. I'm extra paranoid of other races, the price of higher intelligence."
+	desc = "I'm even more anxious than most people. I'm extra paranoid of other races and the sight of blood."
 	var/last_check = 0
 
 /datum/charflaw/paranoid/flaw_on_life(mob/user)
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 
 /datum/charflaw/noeyer
 	name = "Cyclops (R)"
-	desc = "I lost my right eye long ago. But it made me great at noticing things."
+	desc = "I lost my right eye long ago."
 
 /datum/charflaw/noeyer/on_mob_creation(mob/user)
 	..()
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(character_flaws, list("Alcoholic"=/datum/charflaw/addiction/alc
 
 /datum/charflaw/noeyel
 	name = "Cyclops (L)"
-	desc = "I lost my left eye long ago. But it made me great at noticing things."
+	desc = "I lost my left eye long ago."
 
 /datum/charflaw/noeyel/on_mob_creation(mob/user)
 	..()

--- a/code/datums/character_flaw/addiction.dm
+++ b/code/datums/character_flaw/addiction.dm
@@ -77,7 +77,7 @@
 /datum/charflaw/addiction/alcoholic
 	name = "Alcoholic"
 	desc = "Drinking alcohol is my favorite thing."
-	time = 30 MINUTES
+	time = 40 MINUTES
 	needsate_text = "Time for a drink."
 
 
@@ -85,16 +85,16 @@
 
 /datum/charflaw/addiction/junkie
 	name = "Junkie"
-	desc = "I need a real high to take the pain of this rotten world away."
-	time = 30 MINUTES
-	needsate_text = "Time to reach a new high."
+	desc = "I need a REAL high to take the pain of this rotten world away."
+	time = 40 MINUTES
+	needsate_text = "Time to get really high."
 
 /// Smoker
 
 /datum/charflaw/addiction/smoker
 	name = "Smoker"
 	desc = "I need to smoke something to take the edge off."
-	time = 30 MINUTES
+	time = 40 MINUTES
 	needsate_text = "Time for a flavorful smoke."
 
 /// GOD-FEARING
@@ -102,5 +102,5 @@
 /datum/charflaw/addiction/godfearing
 	name = "Devout Follower"
 	desc = "I need to pray to my Patron, their blessings are stronger."
-	time = 25 MINUTES
-	needsate_text = "Time to pray."
+	time = 40 MINUTES
+	needsate_text = "Time to pray to my Patron."

--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -1,5 +1,4 @@
 
-
 /datum/charflaw/limbloss
 	var/lost_zone
 
@@ -38,4 +37,3 @@
 	var/mob/living/carbon/human/H = user
 	var/obj/item/bodypart/l_arm/rproesthetic/L = new()
 	L.attach_limb(H)
-

--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -14,8 +14,8 @@
 	return
 
 /datum/charflaw/limbloss/arm_r
-	name = "No Arm (R)"
-	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much."
+	name = "Wood Arm (R)"
+	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much... but it is flammable."
 	lost_zone = BODY_ZONE_R_ARM
 
 /datum/charflaw/limbloss/arm_r/on_mob_creation(mob/user)
@@ -27,8 +27,8 @@
 	L.attach_limb(H)
 
 /datum/charflaw/limbloss/arm_l
-	name = "No Arm (L)"
-	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much."
+	name = "Wood Arm (L)"
+	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much... but it is flammable."
 	lost_zone = BODY_ZONE_L_ARM
 
 /datum/charflaw/limbloss/arm_l/on_mob_creation(mob/user)

--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -38,3 +38,4 @@
 	var/mob/living/carbon/human/H = user
 	var/obj/item/bodypart/l_arm/rproesthetic/L = new()
 	L.attach_limb(H)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A lot of these flaws have always been worded to be as confusing as possible to everyone on the server. (Especially newbies.)
They don't do anything BUT debuff you, despite the wording implying +int or +per that's just dumbass wording lol.

This also removes the totally fucking random MINUS TWENTY FORTUNE (Luck) the Steward gets for breaking his glasses. He can be blind but that makes no sense what the fuck man. Just break his glasses and then INSTANT crit him? No. Dumb, lol.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The flaws need more depth in general but this is the first step to at least making these less confusing.

Explanation for people who can't press "view changed files and look for the color green and red":
No Arm? Now says Wood Arm that mentions it is flammable.
Cyclops doesn't say it makes you more perceptive, that is a lie. Who wrote that, fucking lol.
Paranoid now tells you that BLOOD makes you paranoid as well as other races. (It has always done this, it just did not say it.)
And the addiction debuff timer is now 40 mins instead of 30 (or 25 for devout, so I will spam admins less now sry guys) meaning it will need to be sated 2-3 times per average 2hr game if you spawn at roundstart. It literally is just a debuff that you need to cleanse with the addiction clearing item (or *pray), and is super easy to clear so it should just be less annoying to deal with overall.

Just less irritating shit to deal with and explain. QOL fix. People should want to engage with flaws as an "RP flavor enhancer" instead of literally a chore to do. Which is what they currently are unless you pick Devout and Zizo sets you on fire which can be funny.

No actual CHANGES to the flaws, JUST how the stuff is worded so we maybe see "why can't I move my fingers" in mentorhelp less.
Except removing -20 Fortune from bad eye havers when they break their glasses because that's _COSMICALLY_ unlucky wtf lol.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
