### PR TITLE
Makes coffins and winding sheets craftable

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -16,6 +16,12 @@
 	reqs = list(/obj/item/natural/cloth = 2)
 	craftdiff = 0
 
+/datum/crafting_recipe/roguetown/sewing/burial_shroud
+	name = "winding sheet"
+	result = list(/obj/item/burial_shroud)
+	reqs = list(/obj/item/natural/cloth = 3)
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/sewing/loincloth
 	name = "loincloth"
 	result = list(/obj/item/clothing/under/roguetown/loincloth)

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -19,7 +19,7 @@
 /datum/crafting_recipe/roguetown/sewing/burial_shroud
 	name = "winding sheet"
 	result = list(/obj/item/burial_shroud)
-	reqs = list(/obj/item/natural/cloth = 3)
+	reqs = list(/obj/item/natural/cloth = 2)
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/loincloth

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -20,7 +20,7 @@
 	name = "winding sheet"
 	result = list(/obj/item/burial_shroud)
 	reqs = list(/obj/item/natural/cloth = 3)
-	craftdiff = 2
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/loincloth
 	name = "loincloth"

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -15,7 +15,7 @@
 	result = /obj/structure/handcart
 	reqs = list(/obj/item/grown/log/tree/small = 3,
 				/obj/item/rope = 1)
-	verbage_simple = "construct"			
+	verbage_simple = "construct"
 	verbage = "constructs"
 
 /datum/crafting_recipe/roguetown/structure/psycrss
@@ -25,7 +25,7 @@
 				/obj/item/grown/log/tree/stake = 3)
 	verbage_simple = "construct"
 	verbage = "constructs"
-	
+
 /datum/crafting_recipe/roguetown/structure/stonepsycrss
 	name = "stone cross"
 	result = /obj/structure/fluff/psycross
@@ -160,7 +160,7 @@
 	result = /obj/structure/fluff/grindwheel
 	reqs = list(/obj/item/ingot/iron = 1,
 				/obj/item/natural/stone = 1)
-	skillcraft = /datum/skill/craft/blacksmithing	
+	skillcraft = /datum/skill/craft/blacksmithing
 	verbage_simple = "build"
 	verbage = "builds"
 	craftsound = null
@@ -320,6 +320,15 @@
 	verbage_simple = "construct"
 	verbage = "constructs"
 	skillcraft = /datum/skill/craft/carpentry
+
+/datum/crafting_recipe/roguetown/structure/coffin
+	name = "coffin"
+	result = /obj/structure/closet/crate/coffin
+	reqs = list(/obj/item/grown/log/tree/small = 2)
+	verbage_simple = "construct"
+	verbage = "constructs"
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 1
 
 /obj/structure/closet/crate/roguecloset/crafted
 	sellprice = 6

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -322,7 +322,7 @@
 	skillcraft = /datum/skill/craft/carpentry
 
 /datum/crafting_recipe/roguetown/structure/coffin
-	name = "coffin"
+	name = "wooden coffin"
 	result = /obj/structure/closet/crate/coffin
 	reqs = list(/obj/item/grown/log/tree/small = 2)
 	verbage_simple = "construct"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Does exactly what it says on the tin. Craft a coffin with two small logs, and a winding sheet with three cloth. Both have crafting difficulty of 1.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Well, besides the obvious benefits to Vampires being able to make more of these, there's also the understated benefit that coffins can be used by Morticians to perform funeral rites, and winding sheets prevent bodies from decaying, which can be useful for churchlings, Doctors, and anyone else who frequently must retrieve, transport, or dispose of corpses.

A side benefit of coffins is that they are useful for underground tombs, as one cannot dig a grave into natural rock formations, making them important for dwarven forts.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
