### PR TITLE
Allows you to dig up sticks instead of stones near trees

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -235,7 +235,7 @@
 			var/mob/living/carbon/human/B = A
 			B.buried = FALSE
 	..()
-	
+
 /obj/structure/closet/dirthole/open(mob/living/user)
 	if(opened)
 		return
@@ -284,9 +284,13 @@
 					else
 						new /obj/item/natural/worms(T)
 		else
-			if(!(locate(/obj/item/natural/stone) in T))
-				if(prob(23))
-					new /obj/item/natural/stone(T)
+			if((locate(/obj/structure/flora/newtree) in view(1)) && !(locate(/obj/item/grown/log/tree/stick) in T))
+				if(prob(33))
+					new /obj/item/grown/log/tree/stick(T)
+			else
+				if(!(locate(/obj/item/natural/stone) in T))
+					if(prob(33))
+						new /obj/item/natural/stone(T)
 	return ..()
 
 /obj/structure/closet/dirthole/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
If you dig a hole in dirt within 1 tile of an un-chopped tree, there is now a 33% chance of a stick spawning instead of a stone, because you might prefer a steady supply of sticks instead of a handful dropping from the sky. Or you want to build a treehouse and need the sticks for platforms.

Also raises the chance of a stone spawning from a hole to 33% because the costs of numerous construction recipes have been crept upward.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes stone arrows, torches, and other things using sticks and stones fully renewable.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
