### PR TITLE
Fixes wrong limbs given after using bodypart miracle

### DIFF
--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -107,7 +107,6 @@
 		limbs += dismembered
 	return limbs
 
-// Now regens limbs and deletes the detached ones afterwards to get around the issue where it gives the wrong limb type upon re-attachment
 /obj/effect/proc_holder/spell/invoked/attach_bodypart/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/human_target = targets[1]
@@ -120,11 +119,10 @@
 		
 		if(length(detached_limbs))
 			human_target.regenerate_limbs(0, limbs_to_regenerate)
-			human_target.visible_message(span_info("The limbs attach to [human_target]!"), \
-								span_notice("I feel my missing limbs re-attach to my body"))
+			human_target.visible_message(span_info("[human_target]'s missing limbs regenerate!"), \
+								span_notice("My missing limbs regenerate!"))
 		else
 			to_chat(user, span_warning("No detached limbs found nearby to regenerate."))
-
 		for(var/obj/item/organ/organ as anything in get_organs(human_target, user))
 			if(human_target.getorganslot(organ.slot) || !organ.Insert(human_target))
 				continue

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -113,19 +113,19 @@
 		var/list/limbs_to_regenerate = human_target.get_missing_limbs()
 		var/list/detached_limbs = get_limbs(human_target, user)
 		var/list/regenerated_limbs = list()
-
 		for(var/body_zone in limbs_to_regenerate)
-			var/obj/item/bodypart/limb_to_delete = find_detached_limb(detached_limbs, body_zone)
-			if(limb_to_delete)
-				regenerated_limbs += body_zone
-				qdel(limb_to_delete)
-
+			for(var/obj/item/bodypart/limb in detached_limbs)
+				if(limb.body_zone == body_zone)
+					regenerated_limbs += body_zone
+					qdel(limb)
+					break
 		if(length(regenerated_limbs))
 			human_target.regenerate_limbs(0, limbs_to_regenerate - regenerated_limbs)
-			human_target.visible_message(span_info("[human_target]'s missing limbs regenerate!"), \
-								span_notice("My missing limbs regenerate!"))
+			human_target.visible_message(span_info("[human_target]'s missing limbs attach to their body!"), \
+								span_notice("My missing limbs attach to my body!"))
 		else
-			to_chat(user, span_warning("No detached limbs found nearby to regenerate."))
+			to_chat(user, span_warning("No detached limbs found nearby to attach."))
+
 
 		for(var/obj/item/organ/organ as anything in get_organs(human_target, user))
 			if(human_target.getorganslot(organ.slot) || !organ.Insert(human_target))

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -142,12 +142,6 @@
 		return TRUE
 	return FALSE
 
-/proc/find_detached_limb(list/detached_limbs, body_zone)
-	for(var/obj/item/bodypart/limb in detached_limbs)
-		if(limb.body_zone == body_zone)
-			return limb
-	return null
-
 // Cure rot
 /obj/effect/proc_holder/spell/invoked/cure_rot
 	name = "Cure Rot"

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -120,7 +120,7 @@
 		
 		if(length(detached_limbs))
 			human_target.regenerate_limbs(0, limbs_to_regenerate)
-			human_target.visible_message(span_info("The limbs attach to [human_target!]"), \
+			human_target.visible_message(span_info("The limbs attach to [human_target]!"), \
 								span_notice("I feel my missing limbs re-attach to my body"))
 		else
 			to_chat(user, span_warning("No detached limbs found nearby to regenerate."))

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -107,15 +107,24 @@
 		limbs += dismembered
 	return limbs
 
-// consider adding functionality to regrow one entire organ or limb per casting?
+// Now regens limbs and deletes the detached ones afterwards to get around the issue where it gives the wrong limb type upon re-attachment
 /obj/effect/proc_holder/spell/invoked/attach_bodypart/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/human_target = targets[1]
-		for(var/obj/item/bodypart/limb as anything in get_limbs(human_target, user))
-			if(human_target.get_bodypart(limb.body_zone) || !limb.attach_limb(human_target))
-				continue
-			human_target.visible_message(span_info("\The [limb] attaches itself to [human_target]!"), \
-								span_notice("\The [limb] attaches itself to me!"))
+		var/list/limbs_to_regenerate = human_target.get_missing_limbs()
+		var/list/detached_limbs = get_limbs(human_target, user)
+		
+		for(var/obj/item/bodypart/limb as anything in detached_limbs)
+			limbs_to_regenerate -= limb.body_zone
+			qdel(limb)
+		
+		if(length(detached_limbs))
+			human_target.regenerate_limbs(0, limbs_to_regenerate)
+			human_target.visible_message(span_info("The limbs attach to [human_target!]"), \
+								span_notice("I feel my missing limbs re-attach to my body"))
+		else
+			to_chat(user, span_warning("No detached limbs found nearby to regenerate."))
+
 		for(var/obj/item/organ/organ as anything in get_organs(human_target, user))
 			if(human_target.getorganslot(organ.slot) || !organ.Insert(human_target))
 				continue
@@ -124,7 +133,7 @@
 		if(!(human_target.mob_biotypes & MOB_UNDEAD))
 			for(var/obj/item/bodypart/limb as anything in human_target.bodyparts)
 				limb.rotted = FALSE
-				limb.skeletonized = FALSE
+				limb.skeletonized = FALSE  
 		human_target.update_body()
 		return TRUE
 	return FALSE

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -112,29 +112,41 @@
 		var/mob/living/carbon/human/human_target = targets[1]
 		var/list/limbs_to_regenerate = human_target.get_missing_limbs()
 		var/list/detached_limbs = get_limbs(human_target, user)
-		
-		for(var/obj/item/bodypart/limb as anything in detached_limbs)
-			limbs_to_regenerate -= limb.body_zone
-			qdel(limb)
-		
-		if(length(detached_limbs))
-			human_target.regenerate_limbs(0, limbs_to_regenerate)
+		var/list/regenerated_limbs = list()
+
+		for(var/body_zone in limbs_to_regenerate)
+			var/obj/item/bodypart/limb_to_delete = find_detached_limb(detached_limbs, body_zone)
+			if(limb_to_delete)
+				regenerated_limbs += body_zone
+				qdel(limb_to_delete)
+
+		if(length(regenerated_limbs))
+			human_target.regenerate_limbs(0, limbs_to_regenerate - regenerated_limbs)
 			human_target.visible_message(span_info("[human_target]'s missing limbs regenerate!"), \
 								span_notice("My missing limbs regenerate!"))
 		else
 			to_chat(user, span_warning("No detached limbs found nearby to regenerate."))
+
 		for(var/obj/item/organ/organ as anything in get_organs(human_target, user))
 			if(human_target.getorganslot(organ.slot) || !organ.Insert(human_target))
 				continue
 			human_target.visible_message(span_info("\The [organ] attaches itself to [human_target]!"), \
 								span_notice("\The [organ] attaches itself to me!"))
+
 		if(!(human_target.mob_biotypes & MOB_UNDEAD))
 			for(var/obj/item/bodypart/limb as anything in human_target.bodyparts)
 				limb.rotted = FALSE
-				limb.skeletonized = FALSE  
+				limb.skeletonized = FALSE
+
 		human_target.update_body()
 		return TRUE
 	return FALSE
+
+/proc/find_detached_limb(list/detached_limbs, body_zone)
+	for(var/obj/item/bodypart/limb in detached_limbs)
+		if(limb.body_zone == body_zone)
+			return limb
+	return null
 
 // Cure rot
 /obj/effect/proc_holder/spell/invoked/cure_rot


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This change maintains the function of the spell whilst fixing an issue that often happens where when using body part miracle to replace someone's arms, it will give the wrong limbs for that species (i.e, drow will get human arms). Since the torso of a species determines how big clothes are on the actual sprite, this caused clothes to outright not fit properly.

It does this by regenerating the limbs using regenerate_limbs() instead of the attachment stuff used before and deletes the corresponding detached limbs nearby to simulate re-attachment whilst ensuring they get the correct limb types.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops people looking fucking retarded by having huge ass human arms disproportionate to their body with clothes that don't fit.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
